### PR TITLE
issue: 60 solo repl dev recovery

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "0.0.5"
+    version = "0.0.6"
     
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -61,6 +61,9 @@ private:
     mutable std::shared_mutex vol_lock_;
     std::map< volume_id_t, VolumePtr > vol_map_;
 
+    mutable std::shared_mutex index_lock_;
+    std::unordered_map< std::string, shared< VolumeIndexTable > > idx_tbl_map_;
+
     bool recovery_done_{false};
     superblk< homeblks_sb_t > sb_;
 

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -68,7 +68,7 @@ TEST_F(VolumeTest, CreateVolumeThenRecover) {
             ASSERT_TRUE(vinfo_ptr != nullptr);
         }
     }
-#if 0
+
     g_helper->restart(5);
 
     // verify the volumes are still there
@@ -82,7 +82,6 @@ TEST_F(VolumeTest, CreateVolumeThenRecover) {
             ASSERT_TRUE(vinfo_ptr != nullptr);
         }
     }
-#endif
 }
 
 int main(int argc, char* argv[]) {

--- a/src/lib/volume/volume.hpp
+++ b/src/lib/volume/volume.hpp
@@ -30,8 +30,8 @@ using VolumePtr = shared< Volume >;
 using VolIdxTablePtr = shared< VolumeIndexTable >;
 
 using ReplDevPtr = shared< homestore::ReplDev >;
+using index_cfg_t = homestore::BtreeConfig;
 class Volume {
-    using index_cfg_t = homestore::BtreeConfig;
 
 public:
     inline static auto const VOL_META_NAME = std::string("Volume2"); // different from old releae;
@@ -90,16 +90,15 @@ public:
 
     VolIdxTablePtr indx_table() const { return indx_tbl_; }
     volume_id_t id() const { return vol_info_->id; };
+    std::string id_str() const { return boost::uuids::to_string(vol_info_->id); };
     ReplDevPtr rd() const { return rd_; }
 
     VolumeInfoPtr info() const { return vol_info_; }
 
     //
-    // This API is called for both volume creation and volume recovery;
     // Initialize index table for this volume and saves the index handle in the volume object;
     //
-    shared< VolumeIndexTable > init_index_table(bool is_recovery,
-                                                homestore::superblk< homestore::index_table_sb >&& sb = {});
+    shared< VolumeIndexTable > init_index_table(bool is_recovery, shared< VolumeIndexTable > tbl = nullptr);
 
 private:
     //


### PR DESCRIPTION
1. Volume index recovery fix
2. Turn on volume recovery test case.
3. Enable volume superblock handler in on_init_complete()

This PR has to wait for HomeStore PR that enables solo repl dev to send on_repl_devs_init_completed() back to HomeBlocks layer after solo repl dev service is started. The HomeStore PR will have to be merged before this PR.



Testing:
========
Tested with private homestore fix and passed.

[03/18/25 16:44:42-07:00] [I] [test_volume] [287573] [iomgr_timer.cpp:179:setup_timer_fd] Creating non-recurring per-thread timer fd 36 and adding it into fd poll list
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [homeblks_impl.hpp:132:on_index_table_found] Recovered index table to index service
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [volume_mgr.cpp:52:recover_index_table] Recovering index table for  index_uuid: 60351b63-9eea-40e5-b699-77478ee64616, parent_uuid: 2b3eba4c-b855-4fb2-9f98-4d458c020621
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [homeblks_impl.hpp:132:on_index_table_found] Recovered index table to index service
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [volume_mgr.cpp:52:recover_index_table] Recovering index table for  index_uuid: 6bee109c-0a97-4c28-ae5e-33aa55fa2f6a, parent_uuid: ee20ebfe-18f7-486a-a34a-8581efa1ad6e
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [generic_repl_svc.cpp:89:start] Repl devs load completed, calling upper layer on_repl_devs_init_completed
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [meta_blk_service.cpp:383:register_handler] [type=Volume2] being registered after scanned from disk.
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [volume.cpp:48:Volume] Volume superblock loaded from disk, vol_info : VolumeInfo: id=2b3eba4c-b855-4fb2-9f98-4d458c020621 size_bytes=1073741824, page_size=4096, name=vol_1
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [volume.cpp:73:init] Getting repl dev for volume: vol_1, uuid: 2b3eba4c-b855-4fb2-9f98-4d458c020621
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [volume.cpp:48:Volume] Volume superblock loaded from disk, vol_info : VolumeInfo: id=ee20ebfe-18f7-486a-a34a-8581efa1ad6e size_bytes=1073741824, page_size=4096, name=vol_0
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [volume.cpp:73:init] Getting repl dev for volume: vol_0, uuid: ee20ebfe-18f7-486a-a34a-8581efa1ad6e
[03/18/25 16:44:42-07:00] [I] [test_volume] [287574] [reactor.hpp:50:IOThreadMetrics] Registring metrics group name = IOThreadMetrics, thread_name = log_flush_thread
[03/18/25 16:44:42-07:00] [I] [test_volume] [287574] [iomgr_timer.cpp:179:setup_timer_fd] Creating non-recurring per-thread timer fd 41 and adding it into fd poll list
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [cp_mgr.cpp:58:start_timer] cp timer is set to 60000000 usec
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [iomgr_timer.cpp:179:setup_timer_fd] Creating recurring global timer fd 45 and adding it into fd poll list
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [resource_mgr.cpp:70:start_timer] resource audit timer is set to 120000 usec
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [iomgr_timer.cpp:179:setup_timer_fd] Creating recurring global timer fd 46 and adding it into fd poll list
[03/18/25 16:44:42-07:00] [I] [test_volume] [287520] [homeblks_impl.cpp:207:init_homestore] Initialize and start HomeStore is successfully
[       OK ] VolumeTest.CreateVolumeThenRecover (5269 ms)
[----------] 1 test from VolumeTest (5269 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (5269 ms total)
[  PASSED  ] 1 test.