### PR TITLE
Issue 83: getStats API implementation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "0.0.13"
+    version = "0.0.14"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")

--- a/src/lib/homeblks_impl.cpp
+++ b/src/lib/homeblks_impl.cpp
@@ -39,8 +39,8 @@ extern std::shared_ptr< HomeBlocks > init_homeblocks(std::weak_ptr< HomeBlocksAp
 }
 
 HomeBlocksStats HomeBlocksImpl::get_stats() const {
-    HomeBlocksStats s;
-    return s;
+    auto const stats = homestore::hs()->repl_service().get_cap_stats();
+    return {stats.total_capacity, stats.used_capacity};
 }
 
 HomeBlocksImpl::~HomeBlocksImpl() {

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -84,6 +84,9 @@ TEST_F(VolumeTest, CreateVolumeThenRecover) {
             // verify the volume is there
             ASSERT_TRUE(vinfo_ptr != nullptr);
         }
+
+        auto const s = hb->get_stats();
+        LOGINFO("Stats: {}", s.to_string());
     }
 
     g_helper->restart(5);


### PR DESCRIPTION
Changes:
1. The stats reported here is consistent with 1.3 AM, that we report two things:
     - Total Initial Capacity 
     - Total Used Capacity
1.3 AM implementation:
https://github.corp.ebay.com/SDS/access-mgr/blob/main/src/backend/homestore/homestore.cpp#L293
2. The capacity reported we use is from homestore replciation service layer which is the data service's virtual dev's total and used size which is also consistent with 1.3 HomeStore's implementation, which was the data blk store's total/used size.

Testing:
=====
Since no write is there yet, used size is zero, the total size is the simulated file size whose total size is around 4GB. 
`[05/08/25 11:46:07-07:00] [I] [test_volume] [138761] [test_volume.cpp:89:TestBody] Stats: total_capacity_bytes=4294967296, used_capacity_bytes=0`