### PR TITLE
Issue 85: Expose data service drive type info to BM

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,8 @@ class HomeBlocksConan(ConanFile):
         self.test_requires("gtest/1.14.0")
 
     def requirements(self):
-        self.requires("homestore/[~6.13]@oss/master", transitive_headers=True)
+        #self.requires("homestore/[~6.13]@oss/master", transitive_headers=True)
+        self.requires("homestore/6.13.10", transitive_headers=True)
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
         self.requires("lz4/1.9.4", override=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,8 +43,7 @@ class HomeBlocksConan(ConanFile):
         self.test_requires("gtest/1.14.0")
 
     def requirements(self):
-        #self.requires("homestore/[~6.13]@oss/master", transitive_headers=True)
-        self.requires("homestore/6.13.10", transitive_headers=True)
+        self.requires("homestore/[~6.13]@oss/master", transitive_headers=True)
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
         self.requires("lz4/1.9.4", override=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "0.0.14"
+    version = "0.0.15"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")
@@ -43,8 +43,7 @@ class HomeBlocksConan(ConanFile):
         self.test_requires("gtest/1.14.0")
 
     def requirements(self):
-        #self.requires("homestore/[~6.13]@oss/master", transitive_headers=True)
-        self.requires("homestore/6.13.10", transitive_headers=True)
+        self.requires("homestore/[~6.13]@oss/master", transitive_headers=True)
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
         self.requires("lz4/1.9.4", override=True)

--- a/src/include/homeblks/home_blks.hpp
+++ b/src/include/homeblks/home_blks.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <list>
-
+#include <iomgr/iomgr_types.hpp>
 #include <sisl/utility/enum.hpp>
 
 #include "common.hpp"
@@ -77,6 +77,7 @@ public:
     virtual peer_id_t our_uuid() const = 0;
     virtual std::shared_ptr< VolumeManager > volume_manager() = 0;
     virtual HomeBlocksStats get_stats() const = 0;
+    virtual iomgr::drive_type data_drive_type() const = 0;
 };
 
 extern std::shared_ptr< HomeBlocks > init_homeblocks(std::weak_ptr< HomeBlocksApplication >&& application);

--- a/src/lib/homeblks_impl.cpp
+++ b/src/lib/homeblks_impl.cpp
@@ -38,6 +38,17 @@ extern std::shared_ptr< HomeBlocks > init_homeblocks(std::weak_ptr< HomeBlocksAp
     return inst;
 }
 
+iomgr::drive_type HomeBlocksImpl::data_drive_type() const {
+    auto const dtype = homestore::hs()->data_service().get_dev_type();
+    if (dtype == homestore::HSDevType::Data) {
+        return iomgr::drive_type::block_hdd;
+    } else if (dtype == homestore::HSDevType::Fast) {
+        return iomgr::drive_type::block_nvme;
+    } else {
+        return iomgr::drive_type::unknown;
+    }
+}
+
 HomeBlocksStats HomeBlocksImpl::get_stats() const {
     auto const stats = homestore::hs()->repl_service().get_cap_stats();
     return {stats.total_capacity, stats.used_capacity};

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -82,6 +82,8 @@ public:
     /// HomeBlocks
     /// Returns the UUID of this HomeBlocks.
     HomeBlocksStats get_stats() const final;
+    iomgr::drive_type data_drive_type() const final;
+
     peer_id_t our_uuid() const final {
         // not expected to be called;
         return peer_id_t{};
@@ -94,16 +96,13 @@ public:
 
     VolumePtr lookup_volume(const volume_id_t& id) final;
 
-    NullAsyncResult write(const VolumePtr& vol, const vol_interface_req_ptr& req,
-        bool part_of_batch = false) final;
+    NullAsyncResult write(const VolumePtr& vol, const vol_interface_req_ptr& req, bool part_of_batch = false) final;
 
-    NullAsyncResult read(const VolumePtr& vol, const vol_interface_req_ptr& req,
-        bool part_of_batch = false) final;
+    NullAsyncResult read(const VolumePtr& vol, const vol_interface_req_ptr& req, bool part_of_batch = false) final;
 
     NullAsyncResult unmap(const VolumePtr& vol, const vol_interface_req_ptr& req) final;
 
     void submit_io_batch() final;
-
 
     // see api comments in base class;
     bool get_stats(volume_id_t id, VolumeStats& stats) const final;

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -65,7 +65,6 @@ private:
 #endif
 };
 
-#if 1
 TEST_F(VolumeTest, CreateDestroyVolume) {
     std::vector< volume_id_t > vol_ids;
     {
@@ -87,15 +86,9 @@ TEST_F(VolumeTest, CreateDestroyVolume) {
         }
 
         auto const s = hb->get_stats();
-        LOGINFO("Stats: {}", s.to_string());
-    }
+        auto const dtype = hb->data_drive_type();
+        LOGINFO("Stats: {}, drive_type: {}", s.to_string(), dtype);
 
-    // verify the volumes are still there
-    {
-        auto hb = g_helper->inst();
-        auto vol_mgr = hb->volume_manager();
-
-#if 1
         for (uint32_t i = 0; i < num_vols; ++i) {
             auto id = vol_ids[i];
             auto ret = vol_mgr->remove_volume(id).get();
@@ -106,14 +99,11 @@ TEST_F(VolumeTest, CreateDestroyVolume) {
             // verify the volume is not there
             ASSERT_TRUE(vinfo_ptr == nullptr);
         }
-#endif
     }
 
     g_helper->restart(5);
 }
-#endif
 
-#if 1
 TEST_F(VolumeTest, CreateVolumeThenRecover) {
     std::vector< volume_id_t > vol_ids;
     {
@@ -183,7 +173,7 @@ TEST_F(VolumeTest, DestroyVolumeCrashRecovery) {
 
     g_helper->restart(5);
 }
-#endif
+
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     ::testing::InitGoogleTest(&parsed_argc, argv);


### PR DESCRIPTION
Change:
======
1. consume HomeStore data service drive type interface and expose new interface to BM to consume.
2. fixed test case issue. 
3. Adjust flip point place to simualate a more edge case that repl dev destroyed, but index table not destroyed. test passed.

Testing:
======
Passed with HomeStore PR: https://github.com/eBay/HomeStore/pull/718

