### PR TITLE
Add submit_io_batch changes.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "1.0.17"
+    version = "1.0.18"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")
@@ -43,7 +43,7 @@ class HomeBlocksConan(ConanFile):
         self.test_requires("gtest/1.14.0")
 
     def requirements(self):
-        self.requires("homestore/[~6.13]@oss/master", transitive_headers=True)
+        self.requires("homestore/[~6.14]@oss/master", transitive_headers=True)
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
         self.requires("lz4/1.9.4", override=True)

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -111,6 +111,8 @@ public:
 
     NullAsyncResult unmap(const VolumePtr& vol, const vol_interface_req_ptr& req) final;
 
+    // Submit the io batch, which is a mandatory method to be called if read/write are issued
+    // with part_of_batchis set to true.
     void submit_io_batch() final;
 
     // see api comments in base class;

--- a/src/lib/volume_mgr.cpp
+++ b/src/lib/volume_mgr.cpp
@@ -257,7 +257,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::unmap(const VolumePtr& vol, const
     return folly::Unit();
 }
 
-void HomeBlocksImpl::submit_io_batch() { RELEASE_ASSERT(false, "submit_io_batch Not implemented"); }
+void HomeBlocksImpl::submit_io_batch() { homestore::data_service().submit_io_batch(); }
 
 void HomeBlocksImpl::on_write(int64_t lsn, const sisl::blob& header, const sisl::blob& key,
                               const std::vector< homestore::MultiBlkId >& new_blkids,


### PR DESCRIPTION
Submit the io batch, which is a mandatory method to be called if read/write are issued with part_of_batch is set to true. In those cases, without this method, IOs might not be even issued. No-op if previous io requests are not part of batch.