### PR TITLE
Vol destroy with outstanding IO

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "1.0.20"
+    version = "1.0.21"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")

--- a/src/lib/homeblks_impl.cpp
+++ b/src/lib/homeblks_impl.cpp
@@ -36,6 +36,7 @@ extern std::shared_ptr< HomeBlocks > init_homeblocks(std::weak_ptr< HomeBlocksAp
     auto inst = std::make_shared< HomeBlocksImpl >(std::move(application));
     inst->init_homestore();
     inst->init_cp();
+    inst->start_reaper_thread();
     return inst;
 }
 
@@ -56,6 +57,13 @@ HomeBlocksStats HomeBlocksImpl::get_stats() const {
 }
 
 HomeBlocksImpl::~HomeBlocksImpl() {
+    LOGI("Shutting down HomeBlocksImpl");
+
+    if (vol_gc_timer_hdl_ != iomgr::null_timer_handle) {
+        iomanager.cancel_timer(vol_gc_timer_hdl_);
+        vol_gc_timer_hdl_ = iomgr::null_timer_handle;
+    }
+
     homestore::hs()->shutdown();
     homestore::HomeStore::reset_instance();
     iomanager.stop();
@@ -298,4 +306,67 @@ void HomeBlocksImpl::on_init_complete() {
 }
 
 void HomeBlocksImpl::init_cp() {}
+
+uint64_t HomeBlocksImpl::gc_timer_secs() const {
+    if (SISL_OPTIONS.count("gc_timer_secs")) {
+        auto const n = SISL_OPTIONS["gc_timer_secs"].as< uint32_t >();
+        LOGINFO("Using gc_timer_secs option value: {}", n);
+        return n;
+    } else {
+        // default to 60 seconds
+        return 120;
+    }
+}
+
+void HomeBlocksImpl::start_reaper_thread() {
+    vol_gc_timer_hdl_ = iomanager.schedule_global_timer(
+        gc_timer_secs() * 1000 * 1000 * 1000, true /* recurring */, nullptr /* cookie */,
+        iomgr::reactor_regex::all_user, [this](void*) { this->vol_gc(); }, true /* wait_to_schedule */);
+}
+
+#if 0
+void HomeBlocksImpl::start_reaper_thread() {
+    folly::Promise< folly::Unit > p;
+    auto f = p.getFuture();
+    iomanager.create_reactor(
+        "volume_reaper", iomgr::INTERRUPT_LOOP, 4u /* num_fibers */, [this, &p](bool is_started) mutable {
+            if (is_started) {
+                reaper_fiber_ = iomanager.iofiber_self();
+                vol_gc_timer_hdl_ = iomanager.schedule_thread_timer(60ull * 1000 * 1000 * 1000, true /* recurring */,
+                                                                    nullptr /*cookie*/, [this](void*) { vol_gc(); });
+                p.setValue();
+            } else {
+                iomanager.cancel_timer(vol_gc_timer_hdl_, true /* wait */);
+                vol_gc_timer_hdl_ = iomgr::null_timer_handle;
+            }
+        });
+
+    std::move(f).get();
+}
+#endif
+void HomeBlocksImpl::vol_gc() {
+    LOGI("Running volume garbage collection");
+    // loop through every volume and call remove volume if volume's ref_cnt is zero;
+    std::vector< VolumePtr > vols_to_remove;
+    {
+        auto lg = std::shared_lock(vol_lock_);
+        for (auto& vol_pair : vol_map_) {
+            auto& vol = vol_pair.second;
+            LOGI("Checking volume with id: {}, is_destroying: {}, can_remove: {}, num_outstanding_reqs: {}",
+                 vol->id_str(), vol->is_destroying(), vol->can_remove(), vol->num_outstanding_reqs());
+
+            if (vol->is_destroying() && vol->can_remove()) {
+                // 1. volume has been issued with removed command before
+                // 2. no one has already started removing it
+                // 3. volume is not in use anymore (ref_cnt == 0)
+                vols_to_remove.push_back(vol);
+            }
+        }
+    }
+
+    for (auto& vol : vols_to_remove) {
+        LOGI("Garbage Collecting removed volume with id: {}", vol->id_str());
+        remove_volume(vol->id());
+    }
+}
 } // namespace homeblocks

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -60,7 +60,7 @@ private:
     std::weak_ptr< HomeBlocksApplication > _application;
     folly::Executor::KeepAlive<> executor_;
 
-    ///
+    /// Volume management
     mutable std::shared_mutex vol_lock_;
     std::map< volume_id_t, VolumePtr > vol_map_;
 
@@ -71,6 +71,9 @@ private:
     bool recovery_done_{false};
     superblk< homeblks_sb_t > sb_;
     peer_id_t our_uuid_;
+
+    iomgr::io_fiber_t reaper_fiber_;
+    iomgr::timer_handle_t vol_gc_timer_hdl_{iomgr::null_timer_handle};
 
 public:
     explicit HomeBlocksImpl(std::weak_ptr< HomeBlocksApplication >&& application);
@@ -125,7 +128,7 @@ public:
     void on_write(int64_t lsn, const sisl::blob& header, const sisl::blob& key,
                   const std::vector< homestore::MultiBlkId >& blkids, cintrusive< homestore::repl_req_ctx >& ctx);
 
-    // VolumeManager::Result< folly::Unit > verify_checksum(vol_read_ctx const& read_ctx);
+    void start_reaper_thread();
 
 private:
     // Should only be called for first-time-boot
@@ -141,6 +144,10 @@ private:
     // recovery apis
     void on_hb_meta_blk_found(sisl::byte_view const& buf, void* cookie);
     void on_vol_meta_blk_found(sisl::byte_view const& buf, void* cookie);
+
+    void vol_gc();
+
+    uint64_t gc_timer_secs() const;
 };
 
 class HBIndexSvcCB : public homestore::IndexServiceCallbacks {

--- a/src/lib/volume/tests/CMakeLists.txt
+++ b/src/lib/volume/tests/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_libraries(test_volume_io
     -rdynamic
 )
 
-add_test(NAME VolumeTest COMMAND test_volume)
+add_test(NAME VolumeTest COMMAND test_volume --gc_timer_secs=5)
 add_test(NAME VolumeIOTest COMMAND test_volume_io)

--- a/src/lib/volume/tests/test_common.hpp
+++ b/src/lib/volume/tests/test_common.hpp
@@ -213,6 +213,31 @@ public:
         }
     }
 
+#ifdef _PRERELEASE
+    void set_flip_point(const std::string flip_name) {
+        flip::FlipCondition null_cond;
+        flip::FlipFrequency freq;
+        freq.set_count(2);
+        freq.set_percent(100);
+        m_fc.inject_noreturn_flip(flip_name, {null_cond}, freq);
+        LOGI("Flip {} set", flip_name);
+    }
+
+    void set_delay_flip(const std::string flip_name, uint64_t delay_usec, uint32_t count = 1, uint32_t percent = 100) {
+        flip::FlipCondition null_cond;
+        flip::FlipFrequency freq;
+        freq.set_count(count);
+        freq.set_percent(percent);
+        m_fc.inject_delay_flip(flip_name, {null_cond}, freq, delay_usec);
+        LOGDEBUG("Flip {} set", flip_name);
+    }
+
+    void remove_flip(const std::string flip_name) {
+        m_fc.remove_flip(flip_name);
+        LOGDEBUG("Flip {} removed", flip_name);
+    }
+#endif
+
 private:
     void init_devices(bool is_file, uint64_t dev_size = 0) {
         if (is_file) {
@@ -275,6 +300,10 @@ private:
     peer_id_t svc_id_;
     Runner io_runner_;
     Waiter waiter_;
+
+#ifdef _PRERELEASE
+    flip::FlipClient m_fc{iomgr_flip::instance()};
+#endif
 };
 
 } // namespace test_common

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -26,8 +26,11 @@
 
 SISL_LOGGING_INIT(HOMEBLOCKS_LOG_MODS)
 SISL_OPTION_GROUP(test_volume_setup,
-                (num_vols, "", "num_vols", "number of volumes", ::cxxopts::value< uint32_t >()->default_value("2"),
-                "number"));
+                  (num_vols, "", "num_vols", "number of volumes", ::cxxopts::value< uint32_t >()->default_value("2"),
+                   "number"),
+                  (gc_timer_secs, "", "gc_timer_secs", "gc timer in seconds",
+                   ::cxxopts::value< uint32_t >()->default_value("5"), "seconds"));
+
 SISL_OPTIONS_ENABLE(logging, test_common_setup, test_volume_setup, homeblocks)
 SISL_LOGGING_DECL(test_volume)
 
@@ -47,23 +50,60 @@ public:
         vol_info.id = hb_utils::gen_random_uuid();
         return vol_info;
     }
-
-#ifdef _PRERELEASE
-    void set_flip_point(const std::string flip_name) {
-        flip::FlipCondition null_cond;
-        flip::FlipFrequency freq;
-        freq.set_count(2);
-        freq.set_percent(100);
-        m_fc.inject_noreturn_flip(flip_name, {null_cond}, freq);
-        LOGI("Flip {} set", flip_name);
-    }
-#endif
-
-private:
-#ifdef _PRERELEASE
-    flip::FlipClient m_fc{iomgr_flip::instance()};
-#endif
 };
+
+TEST_F(VolumeTest, CreateDestroyVolumeWithOutstandingIO) {
+    std::vector< volume_id_t > vol_ids;
+    {
+        auto hb = g_helper->inst();
+        auto vol_mgr = hb->volume_manager();
+
+#ifdef _PRERELEASE
+        uint32_t delay_sec = 10;
+        g_helper->set_delay_flip("vol_fake_io_delay_simulation", delay_sec * 1000 * 1000 /*delay_usec*/, 1, 100);
+#endif
+
+        auto num_vols = 1ul;
+
+        for (uint32_t i = 0; i < num_vols; ++i) {
+            auto vinfo = gen_vol_info(i);
+            auto id = vinfo.id;
+            vol_ids.emplace_back(id);
+            auto ret = vol_mgr->create_volume(std::move(vinfo)).get();
+            ASSERT_TRUE(ret);
+
+            auto vol_ptr = vol_mgr->lookup_volume(id);
+            // verify the volume is there
+            ASSERT_TRUE(vol_ptr != nullptr);
+
+            // fake a write that will be delayed;
+            vol_mgr->write(vol_ptr, nullptr);
+        }
+
+        auto const s = hb->get_stats();
+        auto const dtype = hb->data_drive_type();
+        LOGINFO("Stats: {}, drive_type: {}", s.to_string(), dtype);
+
+        for (uint32_t i = 0; i < num_vols; ++i) {
+            auto id = vol_ids[i];
+            auto ret = vol_mgr->remove_volume(id).get();
+            ASSERT_TRUE(ret);
+            auto delay_secs = 20;
+            LOGINFO("Volume {} removed, waiting for {} seconds for IO to complete", boost::uuids::to_string(id),
+                    delay_secs);
+            // sleep for a while
+            std::this_thread::sleep_for(std::chrono::milliseconds(delay_secs * 1000));
+            auto vol_ptr = vol_mgr->lookup_volume(id);
+            // verify the volume is not there
+            ASSERT_TRUE(vol_ptr == nullptr);
+        }
+    }
+
+#ifdef _PRERELEASE
+    g_helper->remove_flip("vol_fake_io_delay_simulation");
+#endif
+    g_helper->restart(5);
+}
 
 TEST_F(VolumeTest, CreateDestroyVolume) {
     std::vector< volume_id_t > vol_ids;
@@ -141,9 +181,8 @@ TEST_F(VolumeTest, CreateVolumeThenRecover) {
 }
 
 TEST_F(VolumeTest, DestroyVolumeCrashRecovery) {
-
 #ifdef _PRERELEASE
-    set_flip_point("vol_destroy_crash_simulation");
+    g_helper->set_flip_point("vol_destroy_crash_simulation");
 #endif
     std::vector< volume_id_t > vol_ids;
     {

--- a/src/lib/volume/volume.cpp
+++ b/src/lib/volume/volume.cpp
@@ -101,12 +101,12 @@ bool Volume::init(bool is_recovery) {
 }
 
 void Volume::destroy() {
-    // 0. Set destroying state in superblock;
-    state_change(vol_state::DESTROYING);
+    LOGI("Start destroying volume: {}, uuid: {}", vol_info_->name, boost::uuids::to_string(id()));
+    destroy_started_ = true;
 
     // 1. destroy the repl dev;
     if (rd_) {
-        LOGI("Destroying repl dev for volume: {}, uuid: {}", vol_info_->name, boost::uuids::to_string(id()));
+        LOGI("Destroying repl dev for volume: {}", vol_info_->name);
         homestore::hs()->repl_service().remove_repl_dev(id()).get();
         rd_ = nullptr;
     }
@@ -232,7 +232,6 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
 
 VolumeManager::Result< folly::Unit > Volume::write_to_index(lba_t start_lba, lba_t end_lba,
                                                             std::unordered_map< lba_t, BlockInfo >& blocks_info) {
-
     // Use filter callback to get the old blkid.
     homestore::put_filter_cb_t filter_cb = [&blocks_info](BtreeKey const& key, BtreeValue const& existing_value,
                                                           BtreeValue const& value) {

--- a/src/lib/volume_mgr.cpp
+++ b/src/lib/volume_mgr.cpp
@@ -97,10 +97,19 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::remove_volume(const volume_id_t& 
         VolumePtr vol_ptr = nullptr;
         {
             auto lg = std::scoped_lock(vol_lock_);
-            if (auto it = vol_map_.find(id); it != vol_map_.end()) { vol_ptr = it->second; }
+            if (auto it = vol_map_.find(id); it != vol_map_.end()) {
+                vol_ptr = it->second;
+            } else {
+                LOGWARN("Volume with id {} not found, cannot remove", boost::uuids::to_string(id));
+                return folly::Unit();
+            }
         }
 
-        if (vol_ptr) {
+        vol_ptr->state_change(vol_state::DESTROYING);
+
+        // if vol is already started with destroy or there is any outstanding reqs on the vol, we will not do anything
+        // on this vol and let reaper thread to handle it
+        if (vol_ptr->can_remove()) {
             // 2. do volume destroy;
             vol_ptr->destroy();
 #ifdef _PRERELEASE
@@ -114,7 +123,13 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::remove_volume(const volume_id_t& 
 
             LOGINFO("Volume {} removed successfully", vol_ptr->id_str());
         } else {
-            LOGWARN("remove_volume with input id: {} not found", boost::uuids::to_string(id));
+            if (vol_ptr) {
+                LOGD("Volume {} is in destroying state or has outstanding requests: {}, backing off and wait for GC to "
+                     "cleanup.",
+                     vol_ptr->id_str(), vol_ptr->num_outstanding_reqs());
+            } else {
+                LOGWARN("Volume with id {} not found, cannot remove", boost::uuids::to_string(id));
+            }
         }
         // Volume Destructor will be called after vol_ptr goes out of scope;
         return folly::Unit();
@@ -133,19 +148,55 @@ bool HomeBlocksImpl::get_stats(volume_id_t id, VolumeStats& stats) const { retur
 
 void HomeBlocksImpl::get_volume_ids(std::vector< volume_id_t >& vol_ids) const {}
 
-VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol_ptr, const vol_interface_req_ptr& vol_req) {
-    return vol_ptr->write(vol_req);
+VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const vol_interface_req_ptr& vol_req) {
+    if (vol->is_destroying()) {
+        LOGE("Volume {} is in destroying state, cannot write", vol->id_str());
+        return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
+    }
+
+    vol->inc_ref();
+#ifdef _PRERELEASE
+    if (iomgr_flip::instance()->delay_flip("vol_fake_io_delay_simulation", [this, vol]() mutable {
+            LOGI("Resuming fake IO delay flip is done. Do nothing ");
+            vol->dec_ref();
+        })) {
+        LOGI("Slow down vol fake IO flip is enabled, scheduling to call later.");
+        return folly::Unit();
+    }
+#endif
+
+    auto ret = vol->write(vol_req);
+    vol->dec_ref();
+
+    return ret;
 }
 
 VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const vol_interface_req_ptr& req) {
-    return vol->read(req);
+    if (vol->is_destroying()) {
+        LOGE("Volume {} is in destroying state, cannot read", vol->id_str());
+        return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
+    }
+
+    vol->inc_ref();
+    auto ret = vol->read(req);
+    vol->dec_ref();
+    return ret;
 }
 
 VolumeManager::NullAsyncResult HomeBlocksImpl::unmap(const VolumePtr& vol, const vol_interface_req_ptr& req) {
-    RELEASE_ASSERT(false, "Unmap Not implemented");
+    LOGWARN("Unmap to vol: {} not implemented", vol->id_str());
+    if (vol->is_destroying()) {
+        LOGE("Volume {} is in destroying state, cannot unmap", vol->id_str());
+        return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
+    }
+
     return folly::Unit();
 }
 
+//
+// we have to allow submit_io_batch even though a volume is in destroying state, because destroy relies on outstanding
+// IOs to decrease to zero to proceed, e.g. submit_io_batch will allow outstanding io to complete;
+//
 void HomeBlocksImpl::submit_io_batch() { homestore::data_service().submit_io_batch(); }
 
 void HomeBlocksImpl::on_write(int64_t lsn, const sisl::blob& header, const sisl::blob& key,


### PR DESCRIPTION
1. When volume destroy has started, reject all IOs to this volume. 
2. When volume destroy is being started, if there is outstanding IO that has not yet completed, destroy will wait for all IOs to complete for this volume before destroying in async mode;

Testing:
======
1. Add fake IO (just increase outstnding counter, without doing actual write) with delay flip in test_volume that it will delay for customized seconds to complete.
2. Issue volume destroy and we should see it can not proceed and back off, then wait for volume gc thread to kick in to resume destroy when outstanding IOs are completed.


