### PR TITLE
max vol io size

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "1.0.20"
+    version = "1.0.21"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")

--- a/src/include/homeblks/home_blks.hpp
+++ b/src/include/homeblks/home_blks.hpp
@@ -78,6 +78,7 @@ public:
     virtual std::shared_ptr< VolumeManager > volume_manager() = 0;
     virtual HomeBlocksStats get_stats() const = 0;
     virtual iomgr::drive_type data_drive_type() const = 0;
+    virtual uint64_t max_vol_io_size() const = 0;
 };
 
 extern std::shared_ptr< HomeBlocks > init_homeblocks(std::weak_ptr< HomeBlocksApplication >&& application);

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -54,7 +54,7 @@ private:
     static constexpr uint32_t DATA_BLK_SIZE = 4096;
     static constexpr uint32_t SB_FLAGS_GRACEFUL_SHUTDOWN{0x00000001};
     static constexpr uint32_t SB_FLAGS_RESTRICTED{0x00000002};
-
+    static constexpr uint64_t MAX_VOL_IO_SIZE = 1 * Mi; // 1 MiB
 private:
     /// Our SvcId retrieval and SvcId->IP mapping
     std::weak_ptr< HomeBlocksApplication > _application;
@@ -89,6 +89,8 @@ public:
     iomgr::drive_type data_drive_type() const final;
 
     peer_id_t our_uuid() const final { return our_uuid_; }
+
+    uint64_t max_vol_io_size() const final { return MAX_VOL_IO_SIZE; }
 
     /// VolumeManager
     NullAsyncResult create_volume(VolumeInfo&& vol_info) final;


### PR DESCRIPTION
Right now HomeStore 4.x doesn't have any software limit on IO size, volume max IO size becomes something that HomeBlocks concept that not necessary HomeStore possess, given HomeStore is a common engine that support both object/block use cases. 

We hard code 1MiB Max io size which is same as 1.3 release. Should it be larger or smaller, we can change as needed.