### PR TITLE
Issue 68: Graceful shutdown with outstanding IO

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "1.0.25"
+    version = "1.0.27"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")

--- a/src/lib/home_blks_config.fbs
+++ b/src/lib/home_blks_config.fbs
@@ -9,6 +9,9 @@ attribute "deprecated";
 table HomeBlksSettings{
     // reaper thread timer in seconds
     reaper_thread_timer_secs: uint64 = 120;
+
+    //shutdown thread timer in seconds
+    shutdown_thread_timer_secs: uint64 = 5;
 }
 
 root_type HomeBlksSettings;

--- a/src/lib/home_blks_config.fbs
+++ b/src/lib/home_blks_config.fbs
@@ -11,7 +11,7 @@ table HomeBlksSettings{
     reaper_thread_timer_secs: uint64 = 120;
 
     //shutdown thread timer in seconds
-    shutdown_thread_timer_secs: uint64 = 5;
+    shutdown_thread_timer_secs: uint64 = 2;
 }
 
 root_type HomeBlksSettings;

--- a/src/lib/homeblks_impl.cpp
+++ b/src/lib/homeblks_impl.cpp
@@ -57,13 +57,87 @@ HomeBlocksStats HomeBlocksImpl::get_stats() const {
     return {stats.total_capacity, stats.used_capacity};
 }
 
-HomeBlocksImpl::~HomeBlocksImpl() {
-    LOGI("Shutting down HomeBlocksImpl");
+folly::Future< folly::Unit > HomeBlocksImpl::shutdown_start() {
+    LOGI("Setting shutdown start flag");
+    shutdown_started_ = true;
 
-    if (vol_gc_timer_hdl_ != iomgr::null_timer_handle) {
-        iomanager.cancel_timer(vol_gc_timer_hdl_);
-        vol_gc_timer_hdl_ = iomgr::null_timer_handle;
+    auto f = shutdown_promise_.getFuture();
+
+    auto const nsecs = shutdown_timer_nsecs();
+    LOGI("Setting shutdown timer with {} seconds", nsecs);
+    // start timer thread if there are still outstanding jobs;
+    shutdown_timer_hdl_ = iomanager.schedule_global_timer(
+        nsecs * 1000 * 1000 * 1000, true /* recurring */, nullptr /* cookie */, iomgr::reactor_regex::all_user,
+        [this](void*) { this->do_shutdown(); }, true /* wait_to_schedule */);
+
+    return f;
+}
+
+uint64_t HomeBlocksImpl::shutdown_timer_nsecs() const {
+    if (SISL_OPTIONS.count("shutdown_timer_nsecs")) {
+        auto const n = SISL_OPTIONS["shutdown_timer_nsecs"].as< uint32_t >();
+        LOGINFO("Using shutdown_timer_nsecs option value: {}", n);
+        return n;
+    } else {
+        return HB_DYNAMIC_CONFIG(shutdown_thread_timer_secs);
     }
+}
+
+bool HomeBlocksImpl::no_outstanding_vols() const {
+    // check if there are no volumes with outstanding requests;
+    std::shared_lock lg(vol_lock_);
+    for (auto const& vol_pair : vol_map_) {
+        auto const& vol = vol_pair.second;
+        if (vol->num_outstanding_reqs() > 0) {
+            LOGI("Volume {} has outstanding requests: {}", vol->id_str(), vol->num_outstanding_reqs());
+            return false; // found a volume with outstanding requests
+        }
+    }
+
+    LOGI("No volumes with outstanding requests");
+    return true; // no volumes with outstanding requests
+}
+
+bool HomeBlocksImpl::can_shutdown() const {
+    // check if shutdown has started and no outstanding requests;
+    if (is_shutting_down() && no_outstanding_vols() && outstanding_reqs_.test_eq(0)) {
+        LOGI("Shutdown can proceed, outstanding requests: {}", outstanding_reqs_.get());
+        return true;
+    }
+
+    LOGI("Shutdown cannot proceed, outstanding requests: {}", outstanding_reqs_.get());
+    return false;
+}
+
+void HomeBlocksImpl::do_shutdown() {
+    LOGI("Shutdown timer triggered, checking for outstanding requests");
+    if (can_shutdown()) {
+        LOGI("No outstanding requests, proceeding with shutdown");
+
+        shutdown_promise_.setValue();
+    } else {
+        LOGI("Outstanding requests exist, will retry shutdown in {} seconds", shutdown_timer_nsecs());
+    }
+}
+
+HomeBlocksImpl::~HomeBlocksImpl() {
+    LOGI("Shutting down HomeBlocksImpl Received");
+    DEBUG_ASSERT(!is_shutting_down(), "Shutdown already started, cannot destruct HomeBlocksImpl again");
+    // set the shutdown flag so that no new requests are accepted;
+    // start timer thread if there are still outstanding jobs;
+    auto f = shutdown_start();
+
+    std::move(f).get();
+
+    // stop the timer thread
+    if (shutdown_timer_hdl_ != iomgr::null_timer_handle) {
+        iomanager.cancel_timer(shutdown_timer_hdl_);
+        shutdown_timer_hdl_ = iomgr::null_timer_handle;
+    }
+
+    // set the shutdown flag so that no new requests are accepted;
+    sb_->set_flag(SB_FLAGS_GRACEFUL_SHUTDOWN);
+    sb_.write();
 
     homestore::hs()->shutdown();
     homestore::HomeStore::reset_instance();
@@ -351,4 +425,5 @@ void HomeBlocksImpl::vol_gc() {
         remove_volume(vol->id());
     }
 }
+
 } // namespace homeblocks

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -172,6 +172,7 @@ private:
     // If delay flip is not set, false will be returned;
     // If delay flip is set, it will delay the IOs for a given VolumePtr
     bool delay_fake_io(VolumePtr vol);
+    bool crash_simulated_{false};
 #endif
 };
 

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -55,6 +55,7 @@ private:
     static constexpr uint32_t SB_FLAGS_GRACEFUL_SHUTDOWN{0x00000001};
     static constexpr uint32_t SB_FLAGS_RESTRICTED{0x00000002};
     static constexpr uint64_t MAX_VOL_IO_SIZE = 1 * Mi; // 1 MiB
+
 private:
     /// Our SvcId retrieval and SvcId->IP mapping
     std::weak_ptr< HomeBlocksApplication > _application;
@@ -72,8 +73,12 @@ private:
     superblk< homeblks_sb_t > sb_;
     peer_id_t our_uuid_;
 
+    sisl::atomic_counter< uint64_t > outstanding_reqs_{0};
+    bool shutdown_started_{false};
+    folly::Promise< folly::Unit > shutdown_promise_;
     iomgr::io_fiber_t reaper_fiber_;
     iomgr::timer_handle_t vol_gc_timer_hdl_{iomgr::null_timer_handle};
+    iomgr::timer_handle_t shutdown_timer_hdl_{iomgr::null_timer_handle};
 
 public:
     explicit HomeBlocksImpl(std::weak_ptr< HomeBlocksApplication >&& application);
@@ -150,6 +155,17 @@ private:
     void vol_gc();
 
     uint64_t gc_timer_nsecs() const;
+
+    void inc_ref(uint64_t n = 1) { outstanding_reqs_.increment(n); }
+    void dec_ref(uint64_t n = 1) { outstanding_reqs_.decrement(n); }
+    bool is_shutting_down() const { return shutdown_started_; }
+    bool can_shutdown() const;
+
+    bool no_outstanding_vols() const;
+
+    folly::Future< folly::Unit > shutdown_start();
+    void do_shutdown();
+    uint64_t shutdown_timer_nsecs() const;
 
 #ifdef _PRERELEASE
     // For testing purpose only

--- a/src/lib/volume/volume.hpp
+++ b/src/lib/volume/volume.hpp
@@ -159,10 +159,13 @@ public:
 
     VolumeManager::NullAsyncResult read(const vol_interface_req_ptr& req);
 
-    bool can_remove() { return !destroy_started_ && outstanding_reqs_.test_eq(0); }
+    bool can_remove() const { return !destroy_started_ && outstanding_reqs_.test_eq(0); }
 
     void inc_ref(uint64_t n = 1) { outstanding_reqs_.increment(n); }
-    void dec_ref(uint64_t n = 1) { outstanding_reqs_.decrement(n); }
+    void dec_ref(uint64_t n = 1) {
+        DEBUG_ASSERT(outstanding_reqs_.get() >= n, "Cannot decrement outstanding requests below zero");
+        outstanding_reqs_.decrement(n);
+    }
     uint64_t num_outstanding_reqs() const { return outstanding_reqs_.get(); }
 
 private:

--- a/src/lib/volume_mgr.cpp
+++ b/src/lib/volume_mgr.cpp
@@ -66,7 +66,15 @@ shared< VolumeIndexTable > HomeBlocksImpl::recover_index_table(homestore::superb
     }
 }
 
+//
+// The reason create volume needs a ref_cnt:
+// 1. if graceful shutdow is received and visited volume map and check there is no volume being created.
+// 2. after graceful shutdown release the vol map lock, create volume arrives and successfully take the vol map lock,
+// 3. now we have a race that allow create volume to go through and graceful shutdown also happen in parallel which will
+// cause crash;
+//
 VolumeManager::NullAsyncResult HomeBlocksImpl::create_volume(VolumeInfo&& vol_info) {
+    inc_ref();
     auto id = vol_info.id;
     LOGI("[vol={}] is of capacity [{}B]", boost::uuids::to_string(id), vol_info.size_bytes);
 
@@ -74,6 +82,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::create_volume(VolumeInfo&& vol_in
         auto lg = std::shared_lock(vol_lock_);
         if (auto it = vol_map_.find(id); it != vol_map_.end()) {
             LOGW("create_volume with input id: {} already exists,", boost::uuids::to_string(id));
+            dec_ref();
             return folly::makeUnexpected(VolumeError::INVALID_ARG);
         }
     }
@@ -84,12 +93,18 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::create_volume(VolumeInfo&& vol_in
         vol_map_.emplace(std::make_pair(id, vol_ptr));
     } else {
         LOGE("failed to create volume with id: {}", boost::uuids::to_string(id));
+        dec_ref();
         return folly::makeUnexpected(VolumeError::INTERNAL_ERROR);
     }
 
+    dec_ref();
     return folly::Unit();
 }
 
+//
+// Why we don't need do ref_cnt for remove_volume:
+// vol in destroying state already indicates an outstanding volume which consumed in no_outstanding_vols() API;
+//
 VolumeManager::NullAsyncResult HomeBlocksImpl::remove_volume(const volume_id_t& id) {
     iomanager.run_on_forget(iomgr::reactor_regex::random_worker, [this, id]() {
         LOGINFO("remove_volume with input id: {}", boost::uuids::to_string(id));
@@ -113,7 +128,10 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::remove_volume(const volume_id_t& 
             // 2. do volume destroy;
             vol_ptr->destroy();
 #ifdef _PRERELEASE
-            if (iomgr_flip::instance()->test_flip("vol_destroy_crash_simulation")) { return folly::Unit(); }
+            if (iomgr_flip::instance()->test_flip("vol_destroy_crash_simulation")) {
+                crash_simulated_ = true;
+                return folly::Unit();
+            }
 #endif
             // 3. remove volume from vol_map;
             {
@@ -164,10 +182,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const
         return folly::Unit();
     }
 #endif
-    auto ret = vol->write(vol_req);
-    vol->dec_ref();
-
-    return ret;
+    return vol->write(vol_req);
 }
 
 VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const vol_interface_req_ptr& req) {
@@ -185,9 +200,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const 
         return folly::Unit();
     }
 #endif
-    auto ret = vol->read(req);
-    vol->dec_ref();
-    return ret;
+    return vol->read(req);
 }
 
 VolumeManager::NullAsyncResult HomeBlocksImpl::unmap(const VolumePtr& vol, const vol_interface_req_ptr& req) {


### PR DESCRIPTION
To Reviewers:
===========
Please hide whitespaces, there is a bunch of clang-format changes that is non-logic change.

Changes:
========
1. During graceful shutdown, if there are outstanding requests:
      1. Pending create/remove volumes on going, 
      2. Any volume has outstanding IOs,
     Graceful shutdown will wait for all above outstanding requets to complete before proceed.
2. After graceful shutdown is recieved, all create/remove volume and any IO on any volume will be rejected.

Testing
======
1. Add a new test case to trigger a delayed read and write, then do graceful shutdown and it should wait for all IOs to finish before proceeding.
2. Supporting logs show below, shutdown is waiting for outstanding IO to finish (one read and one write) with delay_flip enabled. 

```
[06/06/25 16:43:52-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:130:do_shutdown] Shutdown timer triggered, checking for outstanding requests
[06/06/25 16:43:52-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:108:no_outstanding_vols] Found outstanding volume e207d124-f1be-4a75-b053-ca8447374f95 that has outstanding requests: 2
[06/06/25 16:43:52-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:125:can_shutdown] Shutdown cannot proceed, outstanding requests: 0
[06/06/25 16:43:52-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:136:do_shutdown] Outstanding requests exist, will retry shutdown in 2 seconds
[06/06/25 16:43:54-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:130:do_shutdown] Shutdown timer triggered, checking for outstanding requests
[06/06/25 16:43:54-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:108:no_outstanding_vols] Found outstanding volume e207d124-f1be-4a75-b053-ca8447374f95 that has outstanding requests: 2
[06/06/25 16:43:54-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:125:can_shutdown] Shutdown cannot proceed, outstanding requests: 0
[06/06/25 16:43:54-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:136:do_shutdown] Outstanding requests exist, will retry shutdown in 2 seconds
[06/06/25 16:43:56-07:00] [I] [test_volume] [227698] [volume_mgr.cpp:285:operator()] Resuming fake IO delay flip is done. Do nothing
[06/06/25 16:43:56-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:130:do_shutdown] Shutdown timer triggered, checking for outstanding requests
[06/06/25 16:43:56-07:00] [I] [test_volume] [227698] [volume_mgr.cpp:285:operator()] Resuming fake IO delay flip is done. Do nothing
[06/06/25 16:43:56-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:108:no_outstanding_vols] Found outstanding volume e207d124-f1be-4a75-b053-ca8447374f95 that has outstanding requests: 1
[06/06/25 16:43:56-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:125:can_shutdown] Shutdown cannot proceed, outstanding requests: 0
[06/06/25 16:43:56-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:136:do_shutdown] Outstanding requests exist, will retry shutdown in 2 seconds
[06/06/25 16:43:58-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:130:do_shutdown] Shutdown timer triggered, checking for outstanding requests
[06/06/25 16:43:58-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:114:no_outstanding_vols] No volumes with outstanding requests
[06/06/25 16:43:58-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:121:can_shutdown] Shutdown can proceed, outstanding requests: 0
[06/06/25 16:43:58-07:00] [I] [test_volume] [227741] [homeblks_impl.cpp:132:do_shutdown] No outstanding requests, proceeding with shutdown
```