### PR TITLE
RAII for vol ref_cnt

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "1.0.27"
+    version = "1.0.28"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")

--- a/src/include/homeblks/common.hpp
+++ b/src/include/homeblks/common.hpp
@@ -85,4 +85,6 @@ public:
     static homestore::uuid_t gen_random_uuid();
 };
 
+static constexpr uint32_t MAX_NUM_VOLUMES = 2048;
+
 } // namespace homeblocks

--- a/src/include/homeblks/volume_mgr.hpp
+++ b/src/include/homeblks/volume_mgr.hpp
@@ -16,6 +16,8 @@ ENUM(VolumeError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_VOLUME, U
 using lba_t = uint64_t;
 using lba_count_t = uint32_t;
 
+class Volume;
+using VolumePtr = shared< Volume >;
 struct vol_interface_req : public sisl::ObjLifeCounter< vol_interface_req > {
     uint8_t* buffer{nullptr};
     lba_t lba;
@@ -23,13 +25,20 @@ struct vol_interface_req : public sisl::ObjLifeCounter< vol_interface_req > {
     sisl::atomic_counter< int > refcount;
     bool part_of_batch{false};
     uint64_t request_id;
+    VolumePtr vol{nullptr}; // back refto the volume this request is associated with
 
+    // Set back reference to the volume and adding 1 ref_cnt.
+    void back_ref(VolumePtr vol_ptr);
     friend void intrusive_ptr_add_ref(vol_interface_req* req) { req->refcount.increment(1); }
-
+    friend void intrusive_ptr_release(vol_interface_req* req);
+#if 0
     friend void intrusive_ptr_release(vol_interface_req* req) {
-        if (req->refcount.decrement_testz()) { req->free_yourself(); }
+        if (req->refcount.decrement_testz()) {
+            req->vol->dec_ref(1);
+            req->free_yourself();
+        }
     }
-
+#endif
 public:
     vol_interface_req(uint8_t* const buf, const uint64_t lba, const uint32_t nlbas) :
             buffer(buf), lba(lba), nlbas(nlbas) {}
@@ -85,8 +94,6 @@ struct VolumeStats {
     }
 };
 
-class Volume;
-using VolumePtr = shared< Volume >;
 class VolumeManager : public Manager< VolumeError > {
 public:
     virtual NullAsyncResult create_volume(VolumeInfo&& volume_info) = 0;

--- a/src/include/homeblks/volume_mgr.hpp
+++ b/src/include/homeblks/volume_mgr.hpp
@@ -45,15 +45,20 @@ struct VolumeInfo {
     VolumeInfo() = default;
     VolumeInfo(const VolumeInfo&) = delete;
     VolumeInfo(VolumeInfo&& rhs) noexcept :
-            id(rhs.id), size_bytes(rhs.size_bytes), page_size(rhs.page_size), name(std::move(rhs.name)) {}
+            id(rhs.id),
+            size_bytes(rhs.size_bytes),
+            page_size(rhs.page_size),
+            name(std::move(rhs.name)),
+            ordinal(rhs.ordinal) {}
 
-    VolumeInfo(volume_id_t id_in, uint64_t size, uint64_t psize, std::string in_name) :
-            id(id_in), size_bytes(size), page_size(psize), name(std::move(in_name)) {}
+    VolumeInfo(volume_id_t id_in, uint64_t size, uint64_t psize, std::string in_name, uint64_t ord) :
+            id(id_in), size_bytes(size), page_size(psize), name(std::move(in_name)), ordinal(ord) {}
 
     volume_id_t id;
     uint64_t size_bytes{0};
     uint64_t page_size{0};
     std::string name;
+    uint64_t ordinal;
 
     auto operator<=>(VolumeInfo const& rhs) const {
         return boost::uuids::hash_value(id) <=> boost::uuids::hash_value(rhs.id);
@@ -62,8 +67,8 @@ struct VolumeInfo {
     auto operator==(VolumeInfo const& rhs) const { return id == rhs.id; }
 
     std::string to_string() {
-        return fmt::format("VolumeInfo: id={} size_bytes={}, page_size={}, name={}", boost::uuids::to_string(id),
-                           size_bytes, page_size, name);
+        return fmt::format("VolumeInfo: id={} size_bytes={}, page_size={}, name={} ordinal={}",
+                           boost::uuids::to_string(id), size_bytes, page_size, name, ordinal);
     }
 };
 

--- a/src/lib/homeblks_impl.cpp
+++ b/src/lib/homeblks_impl.cpp
@@ -96,9 +96,6 @@ bool HomeBlocksImpl::no_outstanding_vols() const {
                 continue; // skip volumes that are being removed due to crash simulation
             }
 #endif
-            DEBUG_ASSERT_EQ(vol->num_outstanding_reqs(), 0,
-                            "Volume {} is being removed but has outstanding requests: {}", vol->id_str(),
-                            vol->num_outstanding_reqs());
             LOGI("Found outstanding volume {} that is under destruction.", vol->id_str());
             return false;
         }

--- a/src/lib/homeblks_impl.hpp
+++ b/src/lib/homeblks_impl.hpp
@@ -17,6 +17,7 @@
 #pragma once
 #include <map>
 #include <string>
+#include <sisl/fds/id_reserver.hpp>
 #include <sisl/logging/logging.h>
 #include <sisl/utility/obj_life_counter.hpp>
 #include <homestore/crc.h>
@@ -27,6 +28,7 @@
 #include <homeblks/volume_mgr.hpp>
 #include <homeblks/common.hpp>
 #include "volume/volume.hpp"
+#include "volume/volume_chunk_selector.hpp"
 
 namespace homeblocks {
 
@@ -72,6 +74,11 @@ private:
     bool recovery_done_{false};
     superblk< homeblks_sb_t > sb_;
     peer_id_t our_uuid_;
+    shared< VolumeChunkSelector > chunk_selector_;
+    std::unique_ptr< sisl::IDReserver > ordinal_reserver_;
+
+public:
+    static uint64_t _hs_chunk_size;
 
     sisl::atomic_counter< uint64_t > outstanding_reqs_{0};
     bool shutdown_started_{false};
@@ -147,6 +154,8 @@ private:
 
     DevType get_device_type(std::string const& devname);
     auto defer() const { return folly::makeSemiFuture().via(executor_); }
+
+    void update_vol_sb_cb(uint64_t volume_ordinal, const std::vector< chunk_num_t >& chunk_ids);
 
     // recovery apis
     void on_hb_meta_blk_found(sisl::byte_view const& buf, void* cookie);

--- a/src/lib/volume/CMakeLists.txt
+++ b/src/lib/volume/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library("${PROJECT_NAME}_volume")
 
 target_sources("${PROJECT_NAME}_volume" PRIVATE
     volume.cpp
+    volume_chunk_selector.cpp
     $<TARGET_OBJECTS:${PROJECT_NAME}_core>
 )
 

--- a/src/lib/volume/tests/CMakeLists.txt
+++ b/src/lib/volume/tests/CMakeLists.txt
@@ -22,5 +22,16 @@ target_link_libraries(test_volume_io
     -rdynamic
 )
 
+add_executable(test_volume_chunk_selector)
+target_sources(test_volume_chunk_selector PRIVATE
+test_volume_chunk_selector.cpp
+)
+target_link_libraries(test_volume_chunk_selector
+    ${PROJECT_NAME}_volume
+    ${COMMON_TEST_DEPS}
+    -rdynamic
+)
+
 add_test(NAME VolumeTest COMMAND test_volume --gc_timer_nsecs=3)
 add_test(NAME VolumeIOTest COMMAND test_volume_io)
+add_test(NAME VolumeChunkSelectorTest COMMAND test_volume_chunk_selector)

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -78,10 +78,12 @@ TEST_F(VolumeTest, ShutdownWithOutstandingIO) {
             ASSERT_TRUE(vol_ptr != nullptr);
 
             // fake a write that will be delayed;
-            vol_mgr->write(vol_ptr, nullptr);
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->write(vol_ptr, req1);
 
             // fake a read that will be delayed;
-            vol_mgr->read(vol_ptr, nullptr);
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->read(vol_ptr, req2);
         }
     }
 
@@ -114,10 +116,12 @@ TEST_F(VolumeTest, CreateDestroyVolumeWithOutstandingIO) {
             ASSERT_TRUE(vol_ptr != nullptr);
 
             // fake a write that will be delayed;
-            vol_mgr->write(vol_ptr, nullptr);
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->write(vol_ptr, req1);
 
             // fake a read that will be delayed;
-            vol_mgr->read(vol_ptr, nullptr);
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->read(vol_ptr, req2);
         }
 
         auto const s = hb->get_stats();

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -54,7 +54,6 @@ public:
     }
 };
 
-#if 0
 #ifdef _PRERELEASE
 TEST_F(VolumeTest, ShutdownWithOutstandingRemoveVol) {
     std::vector< volume_id_t > vol_ids;
@@ -102,7 +101,7 @@ TEST_F(VolumeTest, ShutdownWithOutstandingRemoveVol) {
 
     g_helper->restart(2);
 }
-#if 0
+
 TEST_F(VolumeTest, ShutdownWithOutstandingIO) {
     std::vector< volume_id_t > vol_ids;
     {
@@ -195,7 +194,6 @@ TEST_F(VolumeTest, CreateDestroyVolumeWithOutstandingIO) {
 
     g_helper->restart(2);
 }
-#endif
 #endif
 
 TEST_F(VolumeTest, CreateDestroyVolume) {
@@ -319,7 +317,7 @@ TEST_F(VolumeTest, DestroyVolumeCrashRecovery) {
 
     g_helper->restart(2);
 }
-#endif
+
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     char** orig_argv = argv;

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -56,6 +56,53 @@ public:
 
 #if 0
 #ifdef _PRERELEASE
+TEST_F(VolumeTest, ShutdownWithOutstandingRemoveVol) {
+    std::vector< volume_id_t > vol_ids;
+    {
+        auto hb = g_helper->inst();
+        auto vol_mgr = hb->volume_manager();
+
+        uint32_t delay_sec = 6;
+        g_helper->set_delay_flip("vol_fake_io_delay_simulation", delay_sec * 1000 * 1000 /*delay_usec*/, 2, 100);
+
+        auto num_vols = 1ul;
+
+        for (uint32_t i = 0; i < num_vols; ++i) {
+            auto vinfo = gen_vol_info(i);
+            auto id = vinfo.id;
+            vol_ids.emplace_back(id);
+            auto ret = vol_mgr->create_volume(std::move(vinfo)).get();
+            ASSERT_TRUE(ret);
+
+            auto vol_ptr = vol_mgr->lookup_volume(id);
+            // verify the volume is there
+            ASSERT_TRUE(vol_ptr != nullptr);
+
+            // fake a write that will be delayed;
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->write(vol_ptr, req1);
+
+            // fake a read that will be delayed;
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->read(vol_ptr, req2);
+        }
+
+        auto const s = hb->get_stats();
+        auto const dtype = hb->data_drive_type();
+        LOGINFO("Stats: {}, drive_type: {}", s.to_string(), dtype);
+
+        for (uint32_t i = 0; i < num_vols; ++i) {
+            auto id = vol_ids[i];
+            auto ret = vol_mgr->remove_volume(id).get();
+            ASSERT_TRUE(ret);
+        }
+    }
+
+    g_helper->remove_flip("vol_fake_io_delay_simulation");
+
+    g_helper->restart(2);
+}
+#if 0
 TEST_F(VolumeTest, ShutdownWithOutstandingIO) {
     std::vector< volume_id_t > vol_ids;
     {
@@ -148,7 +195,6 @@ TEST_F(VolumeTest, CreateDestroyVolumeWithOutstandingIO) {
 
     g_helper->restart(2);
 }
-
 #endif
 #endif
 
@@ -273,7 +319,7 @@ TEST_F(VolumeTest, DestroyVolumeCrashRecovery) {
 
     g_helper->restart(2);
 }
-
+#endif
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     char** orig_argv = argv;

--- a/src/lib/volume/tests/test_volume_chunk_selector.cpp
+++ b/src/lib/volume/tests/test_volume_chunk_selector.cpp
@@ -1,0 +1,248 @@
+#include <string>
+#include <latch>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <sisl/flip/flip_client.hpp>
+#include <iomgr/iomgr_flip.hpp>
+#include <sisl/options/options.h>
+#include <homeblks/home_blks.hpp>
+#include <homeblks/volume_mgr.hpp>
+#include <volume/volume.hpp>
+#include <volume/volume_chunk_selector.hpp>
+#include "test_common.hpp"
+
+SISL_LOGGING_INIT(HOMEBLOCKS_LOG_MODS)
+SISL_OPTION_GROUP(test_volume_chunk_selector,
+                  (num_vols, "", "num_vols", "number of volumes", ::cxxopts::value< uint32_t >()->default_value("2"),
+                   "number"));
+
+SISL_OPTIONS_ENABLE(logging, test_common_setup, test_volume_chunk_selector, homeblocks)
+SISL_LOGGING_DECL(test_volume_chunk_selector)
+
+using namespace homeblocks;
+
+namespace homestore {
+// This part take from HomeObject test code.
+// This is a fake implementation of Chunk/VChunk to avoid linking with homestore instance.
+// if redefinition error was seen while building this file, any api being added in homestore::Chunk/VChunk, also needs
+// to add one here to avoid redefinition error.
+// Compiler will get confused if symbol can't be resolved locally(e.g. in this file), and will try to find it in
+// homestore library which will cause redefine error.
+class Chunk : public std::enable_shared_from_this< Chunk > {
+public:
+    uint32_t available_blks() const { return m_available_blks; }
+
+    void set_available_blks(uint32_t available_blks) { m_available_blks = available_blks; }
+
+    uint32_t get_defrag_nblks() const { return m_defrag_nblks; }
+
+    void set_defrag_nblks(uint32_t defrag_nblks) { m_defrag_nblks = defrag_nblks; }
+
+    uint32_t get_pdev_id() const { return m_pdev_id; }
+
+    void set_pdev_id(uint32_t pdev_id) { m_pdev_id = pdev_id; }
+
+    uint16_t get_chunk_id() const { return m_chunk_id; }
+
+    blk_num_t get_total_blks() const { return m_total_blks; }
+    void set_chunk_id(uint16_t chunk_id) { m_chunk_id = chunk_id; }
+    uint64_t size() const { return 16 * Ki; }
+
+    Chunk(uint32_t pdev_id, uint16_t chunk_id, uint32_t available_blks = 0, uint32_t defrag_nblks = 0) {
+        m_available_blks = available_blks == 0 ? size() / 4096 : available_blks;
+        m_total_blks = m_available_blks;
+        m_pdev_id = pdev_id;
+        m_chunk_id = chunk_id;
+        m_defrag_nblks = defrag_nblks;
+    }
+
+    uint32_t m_available_blks;
+    uint32_t m_total_blks;
+    uint32_t m_pdev_id;
+    uint16_t m_chunk_id;
+    uint32_t m_defrag_nblks;
+};
+
+VChunk::VChunk(cshared< Chunk >& chunk) : m_internal_chunk(chunk) {}
+
+void VChunk::set_user_private(const sisl::blob& data) {}
+
+const uint8_t* VChunk::get_user_private() const { return nullptr; };
+
+blk_num_t VChunk::available_blks() const { return m_internal_chunk->available_blks(); }
+
+blk_num_t VChunk::get_defrag_nblks() const { return m_internal_chunk->get_defrag_nblks(); }
+
+uint32_t VChunk::get_pdev_id() const { return m_internal_chunk->get_pdev_id(); }
+
+uint16_t VChunk::get_chunk_id() const { return m_internal_chunk->get_chunk_id(); }
+
+blk_num_t VChunk::get_total_blks() const { return m_internal_chunk->get_total_blks(); }
+
+uint64_t VChunk::size() const { return m_internal_chunk->size(); }
+void VChunk::reset() {}
+cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk; }
+
+} // namespace homestore
+
+class ChunkSelectorTest : public ::testing::Test {
+public:
+    ChunkSelectorTest() {}
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+    auto add_chunks_per_pdev(shared< VolumeChunkSelector > chunk_sel, uint32_t pdevs, uint32_t num_chunks_per_pdev) {
+        std::vector< shared< homestore::Chunk > > chunks;
+        for (uint32_t i = 0, chunk_id = 0; i < pdevs; i++) {
+            for (uint32_t j = 0; j < num_chunks_per_pdev; j++) {
+                auto chunk = std::make_shared< homestore::Chunk >(i /*pdev*/, chunk_id++);
+                chunk_sel->add_chunk(chunk);
+                chunks.emplace_back(chunk);
+            }
+        }
+        return chunks;
+    }
+
+#ifdef _PRERELEASE
+    void set_flip_point(const std::string flip_name) {
+        flip::FlipCondition null_cond;
+        flip::FlipFrequency freq;
+        freq.set_count(2);
+        freq.set_percent(100);
+        m_fc.inject_noreturn_flip(flip_name, {null_cond}, freq);
+        LOGI("Flip {} set", flip_name);
+    }
+#endif
+
+private:
+#ifdef _PRERELEASE
+    flip::FlipClient m_fc{iomgr_flip::instance()};
+#endif
+};
+
+TEST_F(ChunkSelectorTest, AllocateReleaseChunksTest) {
+    auto chunk_sel = std::make_shared< VolumeChunkSelector >([this](uint64_t, const std::vector< chunk_num_t >&) {});
+
+    uint32_t pdevs = 3, num_chunks_per_pdev = 20, pdev_id;
+    // Add chunks to chunk selector, each chunk is 16KB, so 3 * 20 * 16KB = 960KB
+    add_chunks_per_pdev(chunk_sel, pdevs, num_chunks_per_pdev);
+    auto init_num_free_chunks = chunk_sel->num_free_chunks();
+
+    // Allocate chunks for multiple volumes to simulate volume create.
+    auto vol1_chunks = chunk_sel->allocate_init_chunks(0 /* ordinal */, 180 * Ki, pdev_id);
+    RELEASE_ASSERT(!vol1_chunks.empty(), "no chunks");
+
+    // Since we lazily allocate chunks, we can allocate more than sum
+    // of all volume sizes. Make sure same chunks not allocated to multiple volumes.
+    for (uint32_t i = 1; i < 5; i++) {
+        auto vol_chunks = chunk_sel->allocate_init_chunks(i /* ordinal */, 180 * Ki, pdev_id);
+        RELEASE_ASSERT(!vol_chunks.empty(), "no chunks");
+        bool noDuplicates = std::none_of(vol1_chunks.begin(), vol1_chunks.end(), [&](int elem) {
+            return std::unordered_set< int >(vol_chunks.begin(), vol_chunks.end()).count(elem) > 0;
+        });
+        RELEASE_ASSERT(noDuplicates, "Duplicate chunks allocated across volumes");
+    }
+
+    // Release all chunks to simulate volume destroy.
+    for (uint32_t i = 0; i < 5; i++) {
+        chunk_sel->release_chunks(i /* ordinal */);
+    }
+
+    // All the chunks will be free.
+    RELEASE_ASSERT_EQ(init_num_free_chunks, chunk_sel->num_free_chunks(), "num free chunks mismatch");
+}
+
+TEST_F(ChunkSelectorTest, SelectChunksTest) {
+    auto chunk_sel = std::make_shared< VolumeChunkSelector >([this](uint64_t, const std::vector< chunk_num_t >&) {});
+    uint32_t pdevs = 3, num_chunks_per_pdev = 20, pdev_id;
+    // Add chunks to chunk selector, each chunk is 16KB, so 3 * 20 * 16KB = 960KB
+    add_chunks_per_pdev(chunk_sel, pdevs, num_chunks_per_pdev);
+
+    // Create volume, get its active chunk list, do select_chunk multiple times.
+    // Make sure every time chunk is selected in round robin fashion from the active ones.
+    auto vol1_chunks = chunk_sel->allocate_init_chunks(0 /* ordinal */, 180 * Ki, pdev_id);
+    RELEASE_ASSERT(!vol1_chunks.empty(), "no chunks");
+
+    // Get the active chunks and make sure its round robin in selection.
+    auto active_chunks = chunk_sel->get_chunks(0);
+    std::vector< homestore::chunk_num_t > active_chunk_ids;
+    for (auto& chunk : active_chunks) {
+        active_chunk_ids.emplace_back(chunk->get_chunk_id());
+    }
+    for (int i = 0; i < 20; i++) {
+        homestore::blk_alloc_hints hints;
+        hints.application_hint = 0;
+        auto chunk = chunk_sel->select_chunk(1 /* nblks */, hints);
+        RELEASE_ASSERT(chunk, "Chunk not available");
+        RELEASE_ASSERT_EQ(chunk->get_chunk_id(), active_chunk_ids[i % active_chunk_ids.size()], "invalid chunk");
+    }
+}
+
+#ifdef _PRERELEASE
+TEST_F(ChunkSelectorTest, ResizeNumChunksTest) {
+    auto latch = std::make_shared< std::latch >(1);
+    auto chunk_sel = std::make_shared< VolumeChunkSelector >(
+        [latch, this](uint64_t vol_ord, const std::vector< chunk_num_t >& chunk_ids) {
+            RELEASE_ASSERT(!chunk_ids.empty(), "Empty chunk ids");
+            latch->count_down();
+        });
+
+    // Set the flip point to trigger resize op.
+    set_flip_point("vol_num_chunks_force_resize_op");
+
+    // Add chunks to chunk selector, each chunk is 16KB, so 3 * 20 * 16KB = 960KB
+    uint32_t pdevs = 3, num_chunks_per_pdev = 20, pdev_id;
+    add_chunks_per_pdev(chunk_sel, pdevs, num_chunks_per_pdev);
+
+    auto initial_chunk_ids = chunk_sel->allocate_init_chunks(0 /* ordinal */, 180 * Ki, pdev_id);
+    RELEASE_ASSERT(!initial_chunk_ids.empty(), "no chunks");
+    auto initial_chunks = chunk_sel->get_chunks(0);
+
+    // This will trigger resize op where additional chunks are created.
+    // We wait till we get the callback notification with new chunk id's
+    homestore::blk_alloc_hints hints;
+    hints.application_hint = 0;
+    auto chunk = chunk_sel->select_chunk(1 /* nblks */, hints);
+    RELEASE_ASSERT(chunk, "Chunk not available");
+    latch->wait();
+
+    auto resized_chunks = chunk_sel->get_chunks(0);
+    RELEASE_ASSERT_GT(resized_chunks.size(), initial_chunks.size(), "Resize op failed");
+}
+#endif
+
+TEST_F(ChunkSelectorTest, RecoverChunksTest) {
+    auto chunk_sel = std::make_shared< VolumeChunkSelector >([this](uint64_t, const std::vector< chunk_num_t >&) {});
+    uint32_t pdevs = 3, num_chunks_per_pdev = 20;
+    // Add chunks to chunk selector, each chunk is 16KB, so 3 * 20 * 16KB = 960KB
+    add_chunks_per_pdev(chunk_sel, pdevs, num_chunks_per_pdev);
+
+    std::vector< homestore::chunk_num_t > chunk_ids;
+    for (uint32_t i = 0; i < 10; i++) {
+        chunk_ids.push_back(i);
+    }
+
+    // Simulate a recovery.
+    chunk_sel->recover_chunks(0 /* ordinal*/, 0 /*pdev */, 180 * Ki, chunk_ids);
+    homestore::blk_alloc_hints hints;
+    hints.application_hint = 0;
+    auto chunk = chunk_sel->select_chunk(1 /* nblks */, hints);
+    RELEASE_ASSERT(chunk, "Chunk not available");
+}
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, test_common_setup, test_volume_chunk_selector, homeblocks);
+    spdlog::set_pattern("[%D %T%z] [%^%l%$] [%n] [%t] %v");
+    sisl::logging::SetLogger("test_volume_chunk_selector");
+    sisl::logging::SetLogPattern("[%D %T%z] [%^%L%$] [%n] [%t] %v");
+    ioenvironment.with_iomgr(iomgr::iomgr_params{.num_threads = 4});
+
+    parsed_argc = 1;
+    auto f = ::folly::Init(&parsed_argc, &argv, true);
+    auto ret = RUN_ALL_TESTS();
+    iomanager.stop();
+    return ret;
+}

--- a/src/lib/volume/volume.cpp
+++ b/src/lib/volume/volume.cpp
@@ -183,7 +183,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
     auto result = rd()->alloc_blks(data_size, hints, new_blkids);
     if (result) {
         LOGE("Failed to allocate blocks");
-        dec_ref();
+        // dec_ref();
         return folly::makeUnexpected(VolumeError::NO_SPACE_LEFT);
     }
 
@@ -196,7 +196,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
         .thenValue(
             [this, vol_req, new_blkids = std::move(new_blkids)](auto&& result) -> VolumeManager::NullAsyncResult {
                 if (result) {
-                    dec_ref();
+                    // dec_ref();
                     return folly::makeUnexpected(VolumeError::DRIVE_WRITE_ERROR);
                 }
 
@@ -226,7 +226,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
                     lba_t end_lba = start_lba + blkid.blk_count() - 1;
                     auto status = write_to_index(start_lba, end_lba, blocks_info);
                     if (!status) {
-                        dec_ref();
+                        // dec_ref();
                         return folly::makeUnexpected(VolumeError::INDEX_ERROR);
                     }
 
@@ -273,7 +273,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
                 return req->result()
                     .via(&folly::InlineExecutor::instance())
                     .thenValue([this](const auto&& result) -> folly::Expected< folly::Unit, VolumeError > {
-                        dec_ref();
+                        // dec_ref();
                         if (result.hasError()) {
                             auto err = result.error();
                             return folly::makeUnexpected(err);
@@ -321,12 +321,12 @@ VolumeManager::NullAsyncResult Volume::read(const vol_interface_req_ptr& req) {
     if (auto index_resp = read_from_index(req, read_ctx.index_kvs); index_resp.hasError()) {
         LOGE("Failed to read from index table for range=[{}, {}], volume id: {}, error: {}", req->lba, req->end_lba(),
              boost::uuids::to_string(id()), index_resp.error());
-        dec_ref();
+        // dec_ref();
         return index_resp;
     }
 
     if (read_ctx.index_kvs.empty()) {
-        dec_ref();
+        // dec_ref();
         return folly::Unit();
     }
 
@@ -341,7 +341,6 @@ VolumeManager::NullAsyncResult Volume::read(const vol_interface_req_ptr& req) {
     // Step 4: verify the checksum after all the reads are done
     return folly::collectAllUnsafe(futs).thenValue(
         [this, req, read_ctx = std::move(read_ctx)](auto&& vf) -> VolumeManager::Result< folly::Unit > {
-            dec_ref();
             for (auto const& err_c : vf) {
                 if (sisl_unlikely(err_c.value())) {
                     auto ec = err_c.value();

--- a/src/lib/volume/volume.cpp
+++ b/src/lib/volume/volume.cpp
@@ -183,7 +183,6 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
     auto result = rd()->alloc_blks(data_size, hints, new_blkids);
     if (result) {
         LOGE("Failed to allocate blocks");
-        // dec_ref();
         return folly::makeUnexpected(VolumeError::NO_SPACE_LEFT);
     }
 
@@ -195,10 +194,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
         ->async_write(new_blkids, data_sgs, vol_req->part_of_batch)
         .thenValue(
             [this, vol_req, new_blkids = std::move(new_blkids)](auto&& result) -> VolumeManager::NullAsyncResult {
-                if (result) {
-                    // dec_ref();
-                    return folly::makeUnexpected(VolumeError::DRIVE_WRITE_ERROR);
-                }
+                if (result) { return folly::makeUnexpected(VolumeError::DRIVE_WRITE_ERROR); }
 
                 using homestore::BlkId;
                 std::vector< BlkId > old_blkids;
@@ -225,10 +221,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
                     // in blocks_info after write_to_index
                     lba_t end_lba = start_lba + blkid.blk_count() - 1;
                     auto status = write_to_index(start_lba, end_lba, blocks_info);
-                    if (!status) {
-                        // dec_ref();
-                        return folly::makeUnexpected(VolumeError::INDEX_ERROR);
-                    }
+                    if (!status) { return folly::makeUnexpected(VolumeError::INDEX_ERROR); }
 
                     start_lba = end_lba + 1;
                 }
@@ -273,7 +266,6 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
                 return req->result()
                     .via(&folly::InlineExecutor::instance())
                     .thenValue([this](const auto&& result) -> folly::Expected< folly::Unit, VolumeError > {
-                        // dec_ref();
                         if (result.hasError()) {
                             auto err = result.error();
                             return folly::makeUnexpected(err);
@@ -321,14 +313,10 @@ VolumeManager::NullAsyncResult Volume::read(const vol_interface_req_ptr& req) {
     if (auto index_resp = read_from_index(req, read_ctx.index_kvs); index_resp.hasError()) {
         LOGE("Failed to read from index table for range=[{}, {}], volume id: {}, error: {}", req->lba, req->end_lba(),
              boost::uuids::to_string(id()), index_resp.error());
-        // dec_ref();
         return index_resp;
     }
 
-    if (read_ctx.index_kvs.empty()) {
-        // dec_ref();
-        return folly::Unit();
-    }
+    if (read_ctx.index_kvs.empty()) { return folly::Unit(); }
 
     // Step 2: Consolidate the blocks by merging the contiguous blkids
     std::vector< folly::Future< std::error_code > > futs;

--- a/src/lib/volume/volume.hpp
+++ b/src/lib/volume/volume.hpp
@@ -159,6 +159,8 @@ public:
 
     VolumeInfoPtr info() const { return vol_info_; }
 
+    std::string to_string() { return vol_info_->to_string(); }
+
     //
     // Initialize index table for this volume and saves the index handle in the volume object;
     //

--- a/src/lib/volume/volume_chunk_selector.cpp
+++ b/src/lib/volume/volume_chunk_selector.cpp
@@ -1,0 +1,374 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+#include "volume_chunk_selector.hpp"
+#include <homeblks/common.hpp>
+#include <iomgr/iomgr_flip.hpp>
+
+namespace homeblocks {
+
+VolumeChunkSelector::VolumeChunkSelector(UpdateVolSbCb update_sb_cb) : m_update_vol_sb_cb(update_sb_cb) {
+    m_volume_chunks.resize(MAX_NUM_VOLUMES);
+}
+
+void VolumeChunkSelector::add_chunk(homestore::cshared< Chunk >& chunk) {
+    // Called during homestore start. Add to both all_chunks and per_device_chunk pool.
+    // Later during volume recovery, assigned chunks are removed from the per_device_chunk pool.
+    auto vol_chunk = std::make_shared< HBChunk >(chunk);
+    auto chunk_id = homestore::VChunk(chunk).get_chunk_id();
+    auto pdev_id = homestore::VChunk(chunk).get_pdev_id();
+    m_all_chunks.emplace(chunk_id, vol_chunk);
+    m_per_dev_chunks[pdev_id].emplace(chunk_id, vol_chunk);
+    LOGDEBUG("Adding chunk id to selector {}", chunk_id);
+}
+
+std::vector< chunk_num_t > VolumeChunkSelector::allocate_init_chunks(uint64_t volume_ordinal, uint64_t volume_size,
+                                                                     uint32_t& pdev_id) {
+    RELEASE_ASSERT(volume_ordinal < m_volume_chunks.size(), "Invalid ordinal for volume {}", volume_ordinal);
+    if (m_volume_chunks[volume_ordinal] != nullptr) {
+        LOGW("Already allocated chunks for volume={}", volume_ordinal);
+        auto volc = m_volume_chunks[volume_ordinal];
+        std::vector< chunk_num_t > chunk_ids;
+        for (auto& chunk : volc->m_chunks) {
+            if (chunk) { chunk_ids.emplace_back(chunk->get_chunk_id()); }
+        }
+        return chunk_ids;
+    }
+
+    uint64_t chunk_size{0};
+    {
+        std::lock_guard lock(m_chunk_sel_mutex);
+        if (m_all_chunks.empty()) {
+            LOGE("No chunks available in system for volume={}", volume_ordinal);
+            return {};
+        }
+
+        chunk_size = m_all_chunks.begin()->second->size();
+    }
+
+    auto volc = std::make_shared< VolumeChunksInfo >();
+    volc->ordinal = volume_ordinal;
+    volc->max_num_chunks = std::max(1UL, (volume_size + chunk_size - 1) / chunk_size);
+    volc->num_active_chunks = std::min(volc->max_num_chunks, static_cast< uint64_t >(num_chunks_per_vol_init));
+
+    // We lazily allocate active chunks and add to chunk vector.
+    // Initially we create num_chunks_per_vol_init active chunks.
+    auto chunks = allocate_init_chunks_from_pdev(volc->num_active_chunks, volc->max_num_chunks);
+    if (chunks.empty()) {
+        LOGE("Couldnt allocate chunks for volume={}", volume_ordinal);
+        return {};
+    }
+
+    volc->pdev = (*chunks.begin())->get_pdev_id();
+    pdev_id = volc->pdev;
+    volc->m_chunks.resize(volc->max_num_chunks);
+    m_volume_chunks[volume_ordinal] = volc;
+
+    std::string str;
+    uint64_t idx = 0;
+    std::vector< chunk_num_t > chunk_ids;
+    for (auto& chunk : chunks) {
+        // Add the chunks to the volume chunk list.
+        RELEASE_ASSERT(chunk->m_vol_ordinal == INVALID_VOL_ORDINAL, "Chunk assigned to volume {}",
+                       chunk->m_vol_ordinal);
+        chunk->m_vol_ordinal = volume_ordinal;
+        chunk_ids.emplace_back(chunk->get_chunk_id());
+        volc->m_chunks[idx++] = chunk;
+        fmt::format_to(std::back_inserter(str), "{} ", chunk->get_chunk_id());
+    }
+
+    LOGI("Allocating initial num_chunks={} for volume={} chunks={}", chunk_ids.size(), volume_ordinal, str);
+    return chunk_ids;
+}
+
+homestore::cshared< Chunk > VolumeChunkSelector::select_chunk(homestore::blk_count_t nblks,
+                                                              const homestore::blk_alloc_hints& hints) {
+
+    if (!hints.application_hint) { return nullptr; }
+    uint64_t volume_ordinal = hints.application_hint.value();
+
+    // We dont take lock on volumes vector and volume chunks vector
+    // as they precreated and never changed
+    auto volc = m_volume_chunks[volume_ordinal];
+
+    // TODO to remove , keep trak of number of freed and alloc blks.
+    // Add chunk_selector interface to have additional functions on_alloc_blk, on_free_blk in homestore.
+    uint32_t total_blks = 0, available_blks = 0, attempts = 0;
+    for (auto& chunk : volc->m_chunks) {
+        if (!chunk) continue;
+        total_blks += chunk->get_total_blks();
+        available_blks += chunk->available_blks();
+    }
+
+    do {
+#ifdef _PRERELEASE
+        if (iomgr_flip::instance()->test_flip("vol_num_chunks_force_resize_op")) {
+            // this is to simulate no blks available.
+            LOGI("Volume resize op flip is set.");
+            resize_volume_num_chunks(nblks, volc);
+        }
+#endif
+
+        // If the ratio of available_blks to total_blks is less than half or there is a request of nblks
+        // more than the available blks and there is room for more chunks then resize.
+        auto usage_ratio = (float)available_blks / total_blks;
+        if ((nblks > available_blks || usage_ratio < 0.5) && (volc->num_active_chunks.load() < volc->max_num_chunks)) {
+            // Check if number chunks needs to be increased.
+            resize_volume_num_chunks(nblks, volc);
+        }
+
+        // This is the fastpath where we try to allocate the blks from the active chunks.
+        // Traverse through active chunks in the vector and find the first chunk
+        // which has some available blks. It may not satisfy all the nblks, in that case
+        // virtual_dev will call select_chunk again.
+        uint64_t num_active_chunks = volc->num_active_chunks;
+        for (uint64_t i = 0; i < num_active_chunks; i++) {
+            if (*volc->m_next_chunk_index >= num_active_chunks) { *volc->m_next_chunk_index = 0; }
+
+            auto chunk = volc->m_chunks[*volc->m_next_chunk_index];
+            *volc->m_next_chunk_index = ((*volc->m_next_chunk_index) + 1);
+            if (chunk && chunk->available_blks() > 0) { return chunk->get_internal_chunk(); }
+        }
+
+        LOGI("Waiting to allocate more chunks");
+        std::this_thread::sleep_for(std::chrono::microseconds(500));
+    } while (++attempts < 100);
+
+    return {};
+}
+
+void VolumeChunkSelector::resize_volume_num_chunks(homestore::blk_count_t nblks, shared< VolumeChunksInfo > volc) {
+    auto idle = ResizeOp::Idle, inprogress = ResizeOp::InProgress;
+    auto status = resize_op.compare_exchange_strong(idle, inprogress);
+    if (!status) {
+        // Some other thread is in process of adding the chunks.
+        return;
+    }
+
+    // TODO chunk select will have on_alloc_blk, on_free_blk
+    uint32_t total_blks = 0, available_blks = 0;
+    for (auto& chunk : volc->m_chunks) {
+        if (!chunk) continue;
+        total_blks += chunk->get_total_blks();
+        available_blks += chunk->available_blks();
+    }
+
+    bool force_resize = false;
+#ifdef _PRERELEASE
+    if (iomgr_flip::instance()->test_flip("vol_num_chunks_force_resize_op")) {
+        // this is to simulate no blks available.
+        LOGI("Volume resize op flip is set.");
+        force_resize = true;
+    }
+#endif
+    if (!force_resize) {
+        auto usage_ratio = (float)available_blks / total_blks;
+        if ((nblks < available_blks && usage_ratio > 0.5)) {
+            // Check again if another thread already did the resize.
+            LOGI("Another thread already completed the resize op.");
+            return;
+        }
+    }
+
+    // Spawn background task to create new chunks.
+    LOGI("Initiating op to resize num chunks for volume={} available={} total={}", volc->ordinal, available_blks,
+         total_blks);
+    iomanager.run_on_forget(iomgr::reactor_regex::random_worker, [volc, this]() mutable {
+        std::string str;
+        auto num_chunks_to_alloc = std::min(static_cast< uint64_t >(num_chunks_per_resize),
+                                            (volc->max_num_chunks - volc->num_active_chunks.load()));
+        auto chunks = allocate_resize_chunks_from_pdev(volc->pdev, num_chunks_to_alloc);
+        RELEASE_ASSERT(!chunks.empty(), "No chunks available for resize volume={}", volc->ordinal)
+
+        // Add the new chunks to the active chunks
+        auto indx = volc->num_active_chunks.load();
+        for (auto chunk : chunks) {
+            volc->m_chunks[indx] = chunk;
+            indx++;
+            fmt::format_to(std::back_inserter(str), "{}({}) ", chunk->get_chunk_id(), chunk->get_pdev_id());
+        }
+
+        std::vector< chunk_num_t > chunk_ids;
+        for (auto& chunk : volc->m_chunks) {
+            if (chunk) { chunk_ids.emplace_back(chunk->get_chunk_id()); }
+        }
+
+        // Persist the new chunk ids to the metablk of volume
+        // before making them active chunks. Invoke the registered callback.
+        m_update_vol_sb_cb(volc->ordinal, chunk_ids);
+
+        // Update the number of active chunks and compelete the resize operation.
+        volc->num_active_chunks = indx;
+        resize_op.store(ResizeOp::Idle);
+        LOGI("Resize op done. Allocated more chunks for volume={} total={} new={} new_chunks={}", volc->ordinal,
+             volc->num_active_chunks.load(), chunks.size(), str);
+    });
+}
+
+std::vector< shared< VolumeChunkSelector::HBChunk > >
+VolumeChunkSelector::allocate_init_chunks_from_pdev(uint64_t init_chunks, uint64_t total_chunks) {
+    std::lock_guard lock(m_chunk_sel_mutex);
+    std::vector< shared< HBChunk > > result;
+    RELEASE_ASSERT(init_chunks < total_chunks, "Invalid chunks requested");
+    for (auto& [pdev, pdev_chunks] : m_per_dev_chunks) {
+        // Find the physical device which has enough total_chunks needed for a volume.
+        if (pdev_chunks.size() >= total_chunks) {
+            auto iter = pdev_chunks.begin();
+            // Assign the init_chunks from the device. Remove chunk from the per
+            // device map so that we dont allocate it to another volume.
+            for (uint32_t i = 0; i < init_chunks; i++) {
+                result.emplace_back(iter->second);
+                iter = pdev_chunks.erase(iter);
+            }
+            break;
+        }
+    }
+
+    return result;
+}
+
+std::vector< shared< VolumeChunkSelector::HBChunk > >
+VolumeChunkSelector::allocate_resize_chunks_from_pdev(uint32_t pdev_id, uint64_t num_chunks) {
+    std::lock_guard lock(m_chunk_sel_mutex);
+    std::vector< shared< HBChunk > > result;
+    auto& chunks = m_per_dev_chunks[pdev_id];
+    RELEASE_ASSERT(num_chunks <= chunks.size(), "Not enough chunks for volume");
+
+    // Allocate chunks from this pdev pool.
+    uint32_t count = 0;
+    for (auto iter = chunks.begin(); iter != chunks.end() && count < num_chunks; count++) {
+        result.emplace_back(iter->second);
+        iter = chunks.erase(iter);
+    }
+
+    return result;
+}
+
+bool VolumeChunkSelector::recover_chunks(uint64_t volume_ordinal, uint32_t pdev, uint64_t volume_size,
+                                         const std::vector< chunk_num_t >& chunk_ids) {
+    std::lock_guard lock(m_chunk_sel_mutex);
+    auto volc = m_volume_chunks[volume_ordinal];
+    RELEASE_ASSERT(!volc, "Volume already exists");
+
+    auto chunk_size = m_all_chunks.begin()->second->size();
+    volc = std::make_shared< VolumeChunksInfo >();
+    volc->ordinal = volume_ordinal;
+    volc->pdev = pdev;
+    volc->max_num_chunks = std::max(1UL, (volume_size + chunk_size - 1) / chunk_size);
+    volc->num_active_chunks = chunk_ids.size();
+    volc->m_chunks.resize(volc->max_num_chunks);
+    m_volume_chunks[volume_ordinal] = volc;
+
+    std::string str;
+    uint32_t indx = 0;
+    for (auto& chunk_id : chunk_ids) {
+        // Add the chunks to the volume chunk list.
+        auto chunk = m_all_chunks[chunk_id];
+        if (!chunk) {
+            LOGE("Chunk not found vol={} chunk_id={}", volume_ordinal, chunk_id);
+            return false;
+        }
+        RELEASE_ASSERT(chunk->m_vol_ordinal == INVALID_VOL_ORDINAL, "Chunk assigned to volume {}",
+                       chunk->m_vol_ordinal);
+        RELEASE_ASSERT(chunk->get_pdev_id() == pdev, "Invalid pdev for chunk");
+        chunk->m_vol_ordinal = volume_ordinal;
+        volc->m_chunks[indx++] = chunk;
+
+        // Remove from per device chunk pool as its assigned to this volume.
+        auto res = m_per_dev_chunks[chunk->get_pdev_id()].erase(chunk_id);
+        RELEASE_ASSERT(res == 1, "Chunk not found {}", chunk_id);
+        fmt::format_to(std::back_inserter(str), "{} ", chunk_id);
+    }
+
+    LOGI("Recovered volume={} num_chunks={}", volume_ordinal, chunk_ids.size());
+    LOGDEBUG("Recovered chunks={}", str);
+    return true;
+}
+
+void VolumeChunkSelector::release_chunks(uint64_t volume_ordinal) {
+    // Release the active chunks back to the per device chunk pool.
+    std::lock_guard lock(m_chunk_sel_mutex);
+    std::string str;
+    uint64_t count = 0;
+    auto volc = m_volume_chunks[volume_ordinal];
+    RELEASE_ASSERT(volc, "Volume doesnt exists");
+
+    for (auto chunk : volc->m_chunks) {
+        if (chunk) {
+            chunk->m_vol_ordinal = INVALID_VOL_ORDINAL;
+            m_per_dev_chunks[chunk->get_pdev_id()].emplace(chunk->get_chunk_id(), chunk);
+            fmt::format_to(std::back_inserter(str), "{} ", chunk->get_chunk_id());
+            count++;
+        }
+    }
+
+    m_volume_chunks[volume_ordinal] = nullptr;
+    LOGI("Released chunks for volume={} num_chunks={}", volume_ordinal, count);
+    LOGDEBUG("Released chunks={}", str);
+}
+
+void VolumeChunkSelector::foreach_chunks(std::function< void(homestore::cshared< Chunk >&) >&& cb) {
+    for (const auto& [_, vol_chunk] : m_all_chunks) {
+        cb(vol_chunk->get_internal_chunk());
+    }
+}
+
+std::vector< shared< VolumeChunkSelector::HBChunk > > VolumeChunkSelector::get_chunks(uint64_t volume_ordinal) {
+    std::lock_guard lock(m_chunk_sel_mutex);
+    std::vector< shared< VolumeChunkSelector::HBChunk > > chunks;
+
+    RELEASE_ASSERT(volume_ordinal < m_volume_chunks.size(), "Invalid ordinal for volume {}", volume_ordinal);
+    if (!m_volume_chunks[volume_ordinal]) { return {}; }
+    for (auto& chunk : m_volume_chunks[volume_ordinal]->m_chunks) {
+        if (!chunk) { continue; }
+        chunks.emplace_back(chunk);
+    }
+    return chunks;
+}
+
+uint64_t VolumeChunkSelector::num_free_chunks() const {
+    std::lock_guard lock(m_chunk_sel_mutex);
+    uint64_t count = 0;
+    for (const auto& [pdev, chunks] : m_per_dev_chunks) {
+        count += chunks.size();
+    }
+    return count;
+}
+
+void VolumeChunkSelector::dump_per_pdev_chunks() const {
+    std::lock_guard lock(m_chunk_sel_mutex);
+    for (const auto& [pdev, chunks] : m_per_dev_chunks) {
+        std::string str;
+        for (const auto& [chunk_id, _] : chunks) {
+            fmt::format_to(std::back_inserter(str), "{} ", chunk_id);
+        }
+        LOGI("pdev={} num_chunks={} chunks={}", pdev, chunks.size(), str);
+    }
+}
+
+void VolumeChunkSelector::dump_chunks() const {
+    std::lock_guard lock(m_chunk_sel_mutex);
+    for (uint32_t i = 0; i < m_volume_chunks.size(); i++) {
+        if (!m_volume_chunks[i]) { continue; }
+        std::string str;
+        for (const auto& chunk : m_volume_chunks[i]->m_chunks) {
+            if (!chunk) { continue; }
+            fmt::format_to(std::back_inserter(str), "{}({}/{}) ", chunk->get_chunk_id(), chunk->available_blks(),
+                           chunk->get_total_blks());
+        }
+        LOGI("volume={} num_chunks={} chunks={}", i, m_volume_chunks[i]->m_chunks.size(), str);
+    }
+}
+
+} // namespace homeblocks

--- a/src/lib/volume/volume_chunk_selector.hpp
+++ b/src/lib/volume/volume_chunk_selector.hpp
@@ -1,0 +1,117 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <list>
+#include <folly/ThreadLocal.h>
+#include <homestore/chunk_selector.h>
+#include <homestore/vchunk.h>
+#include <homestore/homestore_decl.hpp>
+#include <homestore/homestore.hpp>
+#include "homeblks/common.hpp"
+
+namespace homeblocks {
+
+using chunk_num_t = homestore::chunk_num_t;
+using Chunk = homestore::Chunk;
+
+class VolumeChunkSelector : public homestore::ChunkSelector {
+    static constexpr homestore::chunk_num_t num_chunks_per_vol_init = 1;
+    static constexpr homestore::chunk_num_t num_chunks_per_resize = 3;
+    static constexpr uint64_t INVALID_VOL_ORDINAL = UINT64_MAX;
+
+    struct HBChunk : public homestore::VChunk {
+        HBChunk(homestore::cshared< Chunk >& chunk) : homestore::VChunk(chunk) {}
+        ~HBChunk() = default;
+        uint64_t m_vol_ordinal{INVALID_VOL_ORDINAL};
+    };
+
+    struct VolumeChunksInfo {
+        // List of active chunks allocated for the volume.
+        // Each volume is assigned and physical device and
+        // all chunks are allocated from same physical device.
+        std::vector< shared< HBChunk > > m_chunks;
+
+        // max_num_chunks is total chunks possible for whole volume
+        // size. num_active_chunks is the number of chunks which is
+        // used for allocation. next_chunk_index is thread local
+        // which does round robin on the active chunks
+        uint64_t max_num_chunks;
+        std::atomic< uint64_t > num_active_chunks{0};
+        folly::ThreadLocal< uint32_t > m_next_chunk_index;
+        uint64_t ordinal;
+        uint32_t pdev;
+    };
+
+public:
+    using UpdateVolSbCb = std::function< void(uint64_t ordinal, const std::vector< chunk_num_t >&) >;
+    VolumeChunkSelector(UpdateVolSbCb update_sb_cb);
+    ~VolumeChunkSelector() = default;
+
+    // Allocate some initial set of chunks during volume or index create. The number is num_chunks_per_resize
+    std::vector< chunk_num_t > allocate_init_chunks(uint64_t volume_ordinal, uint64_t volume_size, uint32_t& pdev_id);
+
+    // Called during destroy of volume or index.
+    void release_chunks(uint64_t volume_ordinal);
+
+    // Called during recovery of volume or index .
+    bool recover_chunks(uint64_t volume_ordinal, uint32_t pdev_id, uint64_t volume_size,
+                        const std::vector< chunk_num_t >& chunk_ids);
+
+    // Called by homestore during start.
+    void add_chunk(homestore::cshared< Chunk >&) override;
+
+    // Called by homestore during cp flush.
+    void foreach_chunks(std::function< void(homestore::cshared< Chunk >&) >&& cb) override;
+
+    // Called by homestore during blk alloc.
+    homestore::cshared< Chunk > select_chunk(homestore::blk_count_t nblks,
+                                             const homestore::blk_alloc_hints& hints) override;
+
+    std::vector< shared< VolumeChunkSelector::HBChunk > > get_chunks(uint64_t volume_ordinal);
+    uint64_t num_free_chunks() const;
+
+private:
+    std::vector< shared< HBChunk > > allocate_init_chunks_from_pdev(uint64_t init_chunks, uint64_t total_chunks);
+    std::vector< shared< HBChunk > > allocate_resize_chunks_from_pdev(uint32_t pdev, uint64_t num_chunks);
+    void resize_volume_num_chunks(homestore::blk_count_t nblks, shared< VolumeChunksInfo > volc);
+    void dump_per_pdev_chunks() const;
+    void dump_chunks() const;
+
+private:
+    enum class ResizeOp {
+        Idle,
+        InProgress,
+    };
+
+    // Store volume chunks details with index as volume ordinal.
+    std::vector< shared< VolumeChunksInfo > > m_volume_chunks;
+
+    using ChunkMap = std::unordered_map< chunk_num_t, shared< HBChunk > >;
+
+    // Mapping of chunk id to chunk. All chunks assigned to volume and
+    // unassigned chunks are stored in this pool.
+    ChunkMap m_all_chunks;
+
+    // Mapping from physical device to group of chunks which are available
+    // for allocation. This pool is used for allocation of chunks to volume.
+    // Chunks once allocated to volume are removed from this pool.
+    std::unordered_map< uint64_t, ChunkMap > m_per_dev_chunks;
+    mutable std::mutex m_chunk_sel_mutex;
+    UpdateVolSbCb m_update_vol_sb_cb;
+    std::atomic< ResizeOp > resize_op{ResizeOp::Idle};
+};
+
+} // namespace homeblocks

--- a/src/lib/volume_mgr.cpp
+++ b/src/lib/volume_mgr.cpp
@@ -192,7 +192,7 @@ bool HomeBlocksImpl::get_stats(volume_id_t id, VolumeStats& stats) const { retur
 
 void HomeBlocksImpl::get_volume_ids(std::vector< volume_id_t >& vol_ids) const {}
 
-VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const vol_interface_req_ptr& vol_req) {
+VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const vol_interface_req_ptr& req) {
     if (vol->is_destroying() || is_shutting_down()) {
         LOGE(
             "Can't serve write, Volume {} is_destroying: {} is either in destroying state or System is shutting down. ",
@@ -200,7 +200,8 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const
         return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
     }
 
-    vol->inc_ref();
+    req->back_ref(vol);
+    // vol->inc_ref();
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->write
@@ -208,7 +209,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const
         return folly::Unit();
     }
 #endif
-    return vol->write(vol_req);
+    return vol->write(req);
 }
 
 VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const vol_interface_req_ptr& req) {
@@ -218,7 +219,8 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const 
         return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
     }
 
-    vol->inc_ref();
+    req->back_ref(vol);
+    // vol->inc_ref();
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->read
@@ -305,6 +307,19 @@ void HomeBlocksImpl::on_write(int64_t lsn, const sisl::blob& header, const sisl:
     if (repl_ctx) { repl_ctx->promise_.setValue(folly::Unit()); }
 }
 
+void vol_interface_req::back_ref(VolumePtr vol_ptr) {
+    DEBUG_ASSERT(vol == nullptr, "not expecting back ref to volume when vol is already set, vol={}", vol->to_string());
+    vol = vol_ptr;
+    vol->inc_ref(1); // increase ref_cnt for the volume
+}
+
+void intrusive_ptr_release(vol_interface_req* req) {
+    if (req->refcount.decrement_testz()) {
+        req->vol->dec_ref(1);
+        req->free_yourself();
+    }
+}
+
 #ifdef _PRERELEASE
 bool HomeBlocksImpl::delay_fake_io(VolumePtr v) {
     if (iomgr_flip::instance()->delay_flip("vol_fake_io_delay_simulation", [this, v]() mutable {
@@ -312,6 +327,7 @@ bool HomeBlocksImpl::delay_fake_io(VolumePtr v) {
             v->dec_ref();
         })) {
         LOGI("Slow down vol fake IO flip is enabled, scheduling to call later.");
+        v->inc_ref();
         return true;
     }
     return false;

--- a/src/lib/volume_mgr.cpp
+++ b/src/lib/volume_mgr.cpp
@@ -201,7 +201,6 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const
     }
 
     req->back_ref(vol);
-    // vol->inc_ref();
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->write
@@ -220,7 +219,6 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const 
     }
 
     req->back_ref(vol);
-    // vol->inc_ref();
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->read


### PR DESCRIPTION
Changes:
========
1. Remove all inc_ref/dec_ref from volume layer and concentrate to vol_interface_req, so that we only have one place for increase and decrease and caller doesn't need to worry about failure path.
2. add a new test case to cover shutdown with outstanding remove of volume.


Testing:
=======
New Test passed 
```
[06/13/25 15:36:52-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:122:can_shutdown] Shutdown cannot proceed, outstanding requests: 0
[06/13/25 15:36:52-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:133:do_shutdown] Outstanding requests exist, will retry shutdown in 2 seconds
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:127:do_shutdown] Shutdown timer triggered, checking for outstanding requests
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:99:no_outstanding_vols] Found outstanding volume 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71 that is under destruction.
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:122:can_shutdown] Shutdown cannot proceed, outstanding requests: 0
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:133:do_shutdown] Outstanding requests exist, will retry shutdown in 2 seconds
[06/13/25 15:36:56-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:425:vol_gc] Checking volume with id: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71, is_destroying: true, can_remove: true, num_outstanding_reqs: 0
[06/13/25 15:36:56-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:438:vol_gc] Garbage Collecting removed volume with id: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71
[06/13/25 15:36:56-07:00] [I] [test_volume] [230503] [volume_mgr.cpp:110:operator()] remove_volume with input id: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71
[06/13/25 15:36:56-07:00] [I] [test_volume] [230503] [volume.cpp:104:destroy] Start destroying volume: vol_0, uuid: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71
```