### PR TITLE
Issue 113: RAII for outstanding IOs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "1.0.29"
+    version = "2.0.1"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeBlocksConan(ConanFile):
     name = "homeblocks"
-    version = "1.0.28"
+    version = "1.0.29"
     homepage = "https://github.com/eBay/HomeBlocks"
     description = "Block Store built on HomeStore"
     topics = ("ebay")

--- a/src/include/homeblks/volume_mgr.hpp
+++ b/src/include/homeblks/volume_mgr.hpp
@@ -16,6 +16,8 @@ ENUM(VolumeError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_VOLUME, U
 using lba_t = uint64_t;
 using lba_count_t = uint32_t;
 
+class Volume;
+using VolumePtr = shared< Volume >;
 struct vol_interface_req : public sisl::ObjLifeCounter< vol_interface_req > {
     uint8_t* buffer{nullptr};
     lba_t lba;
@@ -23,13 +25,20 @@ struct vol_interface_req : public sisl::ObjLifeCounter< vol_interface_req > {
     sisl::atomic_counter< int > refcount;
     bool part_of_batch{false};
     uint64_t request_id;
+    VolumePtr vol{nullptr}; // back refto the volume this request is associated with
 
+    // Set back reference to the volume and adding 1 ref_cnt.
+    void back_ref(VolumePtr vol_ptr);
     friend void intrusive_ptr_add_ref(vol_interface_req* req) { req->refcount.increment(1); }
-
+    friend void intrusive_ptr_release(vol_interface_req* req);
+#if 0
     friend void intrusive_ptr_release(vol_interface_req* req) {
-        if (req->refcount.decrement_testz()) { req->free_yourself(); }
+        if (req->refcount.decrement_testz()) {
+            req->vol->dec_ref(1);
+            req->free_yourself();
+        }
     }
-
+#endif
 public:
     vol_interface_req(uint8_t* const buf, const uint64_t lba, const uint32_t nlbas) :
             buffer(buf), lba(lba), nlbas(nlbas) {}
@@ -85,8 +94,6 @@ struct VolumeStats {
     }
 };
 
-class Volume;
-using VolumePtr = shared< Volume >;
 class VolumeManager : public Manager< VolumeError > {
 public:
     virtual NullAsyncResult create_volume(VolumeInfo&& volume_info) = 0;

--- a/src/include/homeblks/volume_mgr.hpp
+++ b/src/include/homeblks/volume_mgr.hpp
@@ -27,22 +27,11 @@ struct vol_interface_req : public sisl::ObjLifeCounter< vol_interface_req > {
     uint64_t request_id;
     VolumePtr vol{nullptr}; // back refto the volume this request is associated with
 
-    // Set back reference to the volume and adding 1 ref_cnt.
-    void back_ref(VolumePtr vol_ptr);
     friend void intrusive_ptr_add_ref(vol_interface_req* req) { req->refcount.increment(1); }
     friend void intrusive_ptr_release(vol_interface_req* req);
-#if 0
-    friend void intrusive_ptr_release(vol_interface_req* req) {
-        if (req->refcount.decrement_testz()) {
-            req->vol->dec_ref(1);
-            req->free_yourself();
-        }
-    }
-#endif
-public:
-    vol_interface_req(uint8_t* const buf, const uint64_t lba, const uint32_t nlbas) :
-            buffer(buf), lba(lba), nlbas(nlbas) {}
 
+public:
+    vol_interface_req(uint8_t* const buf, const uint64_t lba, const uint32_t nlbas, VolumePtr vol_ptr);
     virtual ~vol_interface_req() = default; // override; sisl::ObjLifeCounter should have virtual destructor
     virtual void free_yourself() { delete this; }
     lba_t end_lba() const { return lba + nlbas - 1; }

--- a/src/include/homeblks/volume_mgr.hpp
+++ b/src/include/homeblks/volume_mgr.hpp
@@ -18,6 +18,8 @@ using lba_count_t = uint32_t;
 
 class Volume;
 using VolumePtr = shared< Volume >;
+
+// volume interface request should be freed only after IO is completed.
 struct vol_interface_req : public sisl::ObjLifeCounter< vol_interface_req > {
     uint8_t* buffer{nullptr};
     lba_t lba;
@@ -25,7 +27,7 @@ struct vol_interface_req : public sisl::ObjLifeCounter< vol_interface_req > {
     sisl::atomic_counter< int > refcount;
     bool part_of_batch{false};
     uint64_t request_id;
-    VolumePtr vol{nullptr}; // back refto the volume this request is associated with
+    VolumePtr vol{nullptr}; // back refto the volume this request is associated with.
 
     friend void intrusive_ptr_add_ref(vol_interface_req* req) { req->refcount.increment(1); }
     friend void intrusive_ptr_release(vol_interface_req* req);

--- a/src/lib/homeblks_impl.cpp
+++ b/src/lib/homeblks_impl.cpp
@@ -96,9 +96,6 @@ bool HomeBlocksImpl::no_outstanding_vols() const {
                 continue; // skip volumes that are being removed due to crash simulation
             }
 #endif
-            DEBUG_ASSERT_EQ(vol->num_outstanding_reqs(), 0,
-                            "Volume {} is being removed but has outstanding requests: {}", vol->id_str(),
-                            vol->num_outstanding_reqs());
             LOGI("Found outstanding volume {} that is under destruction.", vol->id_str());
             return false;
         }

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -78,11 +78,11 @@ TEST_F(VolumeTest, ShutdownWithOutstandingRemoveVol) {
             ASSERT_TRUE(vol_ptr != nullptr);
 
             // fake a write that will be delayed;
-            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0, vol_ptr});
             vol_mgr->write(vol_ptr, req1);
 
             // fake a read that will be delayed;
-            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0, vol_ptr});
             vol_mgr->read(vol_ptr, req2);
         }
 
@@ -124,11 +124,11 @@ TEST_F(VolumeTest, ShutdownWithOutstandingIO) {
             ASSERT_TRUE(vol_ptr != nullptr);
 
             // fake a write that will be delayed;
-            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0, vol_ptr});
             vol_mgr->write(vol_ptr, req1);
 
             // fake a read that will be delayed;
-            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0, vol_ptr});
             vol_mgr->read(vol_ptr, req2);
         }
     }
@@ -162,11 +162,11 @@ TEST_F(VolumeTest, CreateDestroyVolumeWithOutstandingIO) {
             ASSERT_TRUE(vol_ptr != nullptr);
 
             // fake a write that will be delayed;
-            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0, vol_ptr});
             vol_mgr->write(vol_ptr, req1);
 
             // fake a read that will be delayed;
-            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0, vol_ptr});
             vol_mgr->read(vol_ptr, req2);
         }
 

--- a/src/lib/volume/tests/test_volume.cpp
+++ b/src/lib/volume/tests/test_volume.cpp
@@ -54,8 +54,54 @@ public:
     }
 };
 
-#if 0
 #ifdef _PRERELEASE
+TEST_F(VolumeTest, ShutdownWithOutstandingRemoveVol) {
+    std::vector< volume_id_t > vol_ids;
+    {
+        auto hb = g_helper->inst();
+        auto vol_mgr = hb->volume_manager();
+
+        uint32_t delay_sec = 6;
+        g_helper->set_delay_flip("vol_fake_io_delay_simulation", delay_sec * 1000 * 1000 /*delay_usec*/, 2, 100);
+
+        auto num_vols = 1ul;
+
+        for (uint32_t i = 0; i < num_vols; ++i) {
+            auto vinfo = gen_vol_info(i);
+            auto id = vinfo.id;
+            vol_ids.emplace_back(id);
+            auto ret = vol_mgr->create_volume(std::move(vinfo)).get();
+            ASSERT_TRUE(ret);
+
+            auto vol_ptr = vol_mgr->lookup_volume(id);
+            // verify the volume is there
+            ASSERT_TRUE(vol_ptr != nullptr);
+
+            // fake a write that will be delayed;
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->write(vol_ptr, req1);
+
+            // fake a read that will be delayed;
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->read(vol_ptr, req2);
+        }
+
+        auto const s = hb->get_stats();
+        auto const dtype = hb->data_drive_type();
+        LOGINFO("Stats: {}, drive_type: {}", s.to_string(), dtype);
+
+        for (uint32_t i = 0; i < num_vols; ++i) {
+            auto id = vol_ids[i];
+            auto ret = vol_mgr->remove_volume(id).get();
+            ASSERT_TRUE(ret);
+        }
+    }
+
+    g_helper->remove_flip("vol_fake_io_delay_simulation");
+
+    g_helper->restart(2);
+}
+
 TEST_F(VolumeTest, ShutdownWithOutstandingIO) {
     std::vector< volume_id_t > vol_ids;
     {
@@ -78,10 +124,12 @@ TEST_F(VolumeTest, ShutdownWithOutstandingIO) {
             ASSERT_TRUE(vol_ptr != nullptr);
 
             // fake a write that will be delayed;
-            vol_mgr->write(vol_ptr, nullptr);
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->write(vol_ptr, req1);
 
             // fake a read that will be delayed;
-            vol_mgr->read(vol_ptr, nullptr);
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->read(vol_ptr, req2);
         }
     }
 
@@ -114,10 +162,12 @@ TEST_F(VolumeTest, CreateDestroyVolumeWithOutstandingIO) {
             ASSERT_TRUE(vol_ptr != nullptr);
 
             // fake a write that will be delayed;
-            vol_mgr->write(vol_ptr, nullptr);
+            vol_interface_req_ptr req1(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->write(vol_ptr, req1);
 
             // fake a read that will be delayed;
-            vol_mgr->read(vol_ptr, nullptr);
+            vol_interface_req_ptr req2(new vol_interface_req{nullptr, 0, 0});
+            vol_mgr->read(vol_ptr, req2);
         }
 
         auto const s = hb->get_stats();
@@ -144,8 +194,6 @@ TEST_F(VolumeTest, CreateDestroyVolumeWithOutstandingIO) {
 
     g_helper->restart(2);
 }
-
-#endif
 #endif
 
 TEST_F(VolumeTest, CreateDestroyVolume) {

--- a/src/lib/volume/tests/test_volume_io.cpp
+++ b/src/lib/volume/tests/test_volume_io.cpp
@@ -140,7 +140,7 @@ public:
         test_common::Waiter waiter(1);
         auto fut = waiter.start([this, vol, start_lba, nblks, &waiter]() mutable {
             auto data = build_random_data(start_lba, nblks);
-            vol_interface_req_ptr req(new vol_interface_req{data->bytes(), start_lba, nblks});
+            vol_interface_req_ptr req(new vol_interface_req{data->bytes(), start_lba, nblks, m_vol_ptr});
             auto vol_mgr = g_helper->inst()->volume_manager();
             vol_mgr->write(m_vol_ptr, req)
                 .via(&folly::InlineExecutor::instance())
@@ -160,7 +160,7 @@ public:
 
     auto generate_io(lba_t start_lba = 0, uint32_t nblks = 0) {
         auto data = build_random_data(start_lba, nblks);
-        vol_interface_req_ptr req(new vol_interface_req{data->bytes(), start_lba, nblks});
+        vol_interface_req_ptr req(new vol_interface_req{data->bytes(), start_lba, nblks, m_vol_ptr});
         auto vol_mgr = g_helper->inst()->volume_manager();
         vol_mgr->write(m_vol_ptr, req)
             .via(&folly::InlineExecutor::instance())
@@ -178,7 +178,7 @@ public:
         auto sz = nlbas * m_vol_ptr->info()->page_size;
         sisl::io_blob_safe read_blob(sz, 512);
         auto buf = read_blob.bytes();
-        vol_interface_req_ptr req(new vol_interface_req{buf, start_lba, nlbas});
+        vol_interface_req_ptr req(new vol_interface_req{buf, start_lba, nlbas, m_vol_ptr});
         auto read_resp = g_helper->inst()->volume_manager()->read(m_vol_ptr, req).get();
         if (read_resp.hasError()) { LOGERROR("Read failed with error={}", read_resp.error()); }
         RELEASE_ASSERT(!read_resp.hasError(), "Read failed with error={}", read_resp.error());

--- a/src/lib/volume/volume.cpp
+++ b/src/lib/volume/volume.cpp
@@ -183,7 +183,6 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
     auto result = rd()->alloc_blks(data_size, hints, new_blkids);
     if (result) {
         LOGE("Failed to allocate blocks");
-        dec_ref();
         return folly::makeUnexpected(VolumeError::NO_SPACE_LEFT);
     }
 
@@ -195,10 +194,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
         ->async_write(new_blkids, data_sgs, vol_req->part_of_batch)
         .thenValue(
             [this, vol_req, new_blkids = std::move(new_blkids)](auto&& result) -> VolumeManager::NullAsyncResult {
-                if (result) {
-                    dec_ref();
-                    return folly::makeUnexpected(VolumeError::DRIVE_WRITE_ERROR);
-                }
+                if (result) { return folly::makeUnexpected(VolumeError::DRIVE_WRITE_ERROR); }
 
                 using homestore::BlkId;
                 std::vector< BlkId > old_blkids;
@@ -225,10 +221,7 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
                     // in blocks_info after write_to_index
                     lba_t end_lba = start_lba + blkid.blk_count() - 1;
                     auto status = write_to_index(start_lba, end_lba, blocks_info);
-                    if (!status) {
-                        dec_ref();
-                        return folly::makeUnexpected(VolumeError::INDEX_ERROR);
-                    }
+                    if (!status) { return folly::makeUnexpected(VolumeError::INDEX_ERROR); }
 
                     start_lba = end_lba + 1;
                 }
@@ -273,7 +266,6 @@ VolumeManager::NullAsyncResult Volume::write(const vol_interface_req_ptr& vol_re
                 return req->result()
                     .via(&folly::InlineExecutor::instance())
                     .thenValue([this](const auto&& result) -> folly::Expected< folly::Unit, VolumeError > {
-                        dec_ref();
                         if (result.hasError()) {
                             auto err = result.error();
                             return folly::makeUnexpected(err);
@@ -321,14 +313,10 @@ VolumeManager::NullAsyncResult Volume::read(const vol_interface_req_ptr& req) {
     if (auto index_resp = read_from_index(req, read_ctx.index_kvs); index_resp.hasError()) {
         LOGE("Failed to read from index table for range=[{}, {}], volume id: {}, error: {}", req->lba, req->end_lba(),
              boost::uuids::to_string(id()), index_resp.error());
-        dec_ref();
         return index_resp;
     }
 
-    if (read_ctx.index_kvs.empty()) {
-        dec_ref();
-        return folly::Unit();
-    }
+    if (read_ctx.index_kvs.empty()) { return folly::Unit(); }
 
     // Step 2: Consolidate the blocks by merging the contiguous blkids
     std::vector< folly::Future< std::error_code > > futs;
@@ -341,7 +329,6 @@ VolumeManager::NullAsyncResult Volume::read(const vol_interface_req_ptr& req) {
     // Step 4: verify the checksum after all the reads are done
     return folly::collectAllUnsafe(futs).thenValue(
         [this, req, read_ctx = std::move(read_ctx)](auto&& vf) -> VolumeManager::Result< folly::Unit > {
-            dec_ref();
             for (auto const& err_c : vf) {
                 if (sisl_unlikely(err_c.value())) {
                     auto ec = err_c.value();

--- a/src/lib/volume/volume.cpp
+++ b/src/lib/volume/volume.cpp
@@ -53,6 +53,7 @@ Volume::Volume(sisl::byte_view const& buf, void* cookie, shared< VolumeChunkSele
     sb_.load(buf, cookie);
     // generate volume info from sb;
     vol_info_ = std::make_shared< VolumeInfo >(sb_->id, sb_->size, sb_->page_size, sb_->name, sb_->ordinal);
+    m_state_ = sb_->state;
     LOGI("Volume superblock loaded from disk, vol_info : {}", vol_info_->to_string());
 }
 
@@ -125,6 +126,9 @@ bool Volume::init(bool is_recovery) {
              chunk_ids.size());
         // index table will be recovered via in subsequent callback with init_index_table API;
     }
+
+    // set the in memory state from superblock;
+    m_state_ = sb_->state;
     return true;
 }
 

--- a/src/lib/volume/volume.hpp
+++ b/src/lib/volume/volume.hpp
@@ -159,6 +159,8 @@ public:
 
     VolumeInfoPtr info() const { return vol_info_; }
 
+    std::string to_string() { return vol_info_->to_string(); }
+
     //
     // Initialize index table for this volume and saves the index handle in the volume object;
     //
@@ -167,6 +169,7 @@ public:
     void destroy();
 
     bool is_destroying() const { return sb_->state == vol_state::DESTROYING; }
+    bool is_destroy_started() const { return destroy_started_; }
 
     //
     // This API will be called to set the volume state and persist to disk;
@@ -185,13 +188,15 @@ public:
 
     VolumeManager::NullAsyncResult read(const vol_interface_req_ptr& req);
 
+    //
+    // if destroy_started_ is true, it means volume destroy has started and we should not call remove again;
+    // if outstanding_reqs_ is not zero, it means there are still requests outstanding and we should not call remove;
+    // destroy_started_ will be set to true when volume destroy starts processing;
+    //
     bool can_remove() const { return !destroy_started_ && outstanding_reqs_.test_eq(0); }
 
     void inc_ref(uint64_t n = 1) { outstanding_reqs_.increment(n); }
-    void dec_ref(uint64_t n = 1) {
-        DEBUG_ASSERT(outstanding_reqs_.get() >= n, "Cannot decrement outstanding requests below zero");
-        outstanding_reqs_.decrement(n);
-    }
+    void dec_ref(uint64_t n = 1) { outstanding_reqs_.decrement(n); }
     uint64_t num_outstanding_reqs() const { return outstanding_reqs_.get(); }
     void update_vol_sb_cb(const std::vector< chunk_num_t >& chunk_ids);
 

--- a/src/lib/volume_mgr.cpp
+++ b/src/lib/volume_mgr.cpp
@@ -200,7 +200,6 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const
         return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
     }
 
-    req->back_ref(vol);
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->write
@@ -218,7 +217,6 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const 
         return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
     }
 
-    req->back_ref(vol);
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->read
@@ -305,10 +303,9 @@ void HomeBlocksImpl::on_write(int64_t lsn, const sisl::blob& header, const sisl:
     if (repl_ctx) { repl_ctx->promise_.setValue(folly::Unit()); }
 }
 
-void vol_interface_req::back_ref(VolumePtr vol_ptr) {
-    DEBUG_ASSERT(vol == nullptr, "not expecting back ref to volume when vol is already set, vol={}", vol->to_string());
-    vol = vol_ptr;
-    vol->inc_ref(1); // increase ref_cnt for the volume
+vol_interface_req::vol_interface_req(uint8_t* const buf, const uint64_t lba, const uint32_t nlbas, VolumePtr vol_ptr) :
+        buffer(buf), lba(lba), nlbas(nlbas), vol(vol_ptr) {
+    vol->inc_ref(1);
 }
 
 void intrusive_ptr_release(vol_interface_req* req) {

--- a/src/lib/volume_mgr.cpp
+++ b/src/lib/volume_mgr.cpp
@@ -192,7 +192,7 @@ bool HomeBlocksImpl::get_stats(volume_id_t id, VolumeStats& stats) const { retur
 
 void HomeBlocksImpl::get_volume_ids(std::vector< volume_id_t >& vol_ids) const {}
 
-VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const vol_interface_req_ptr& vol_req) {
+VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const vol_interface_req_ptr& req) {
     if (vol->is_destroying() || is_shutting_down()) {
         LOGE(
             "Can't serve write, Volume {} is_destroying: {} is either in destroying state or System is shutting down. ",
@@ -200,7 +200,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const
         return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
     }
 
-    vol->inc_ref();
+    req->back_ref(vol);
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->write
@@ -208,7 +208,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::write(const VolumePtr& vol, const
         return folly::Unit();
     }
 #endif
-    return vol->write(vol_req);
+    return vol->write(req);
 }
 
 VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const vol_interface_req_ptr& req) {
@@ -218,7 +218,7 @@ VolumeManager::NullAsyncResult HomeBlocksImpl::read(const VolumePtr& vol, const 
         return folly::makeUnexpected(VolumeError::UNSUPPORTED_OP);
     }
 
-    vol->inc_ref();
+    req->back_ref(vol);
 #ifdef _PRERELEASE
     if (delay_fake_io(vol)) {
         // If we are delaying IO, we return immediately without calling vol->read
@@ -305,6 +305,19 @@ void HomeBlocksImpl::on_write(int64_t lsn, const sisl::blob& header, const sisl:
     if (repl_ctx) { repl_ctx->promise_.setValue(folly::Unit()); }
 }
 
+void vol_interface_req::back_ref(VolumePtr vol_ptr) {
+    DEBUG_ASSERT(vol == nullptr, "not expecting back ref to volume when vol is already set, vol={}", vol->to_string());
+    vol = vol_ptr;
+    vol->inc_ref(1); // increase ref_cnt for the volume
+}
+
+void intrusive_ptr_release(vol_interface_req* req) {
+    if (req->refcount.decrement_testz()) {
+        req->vol->dec_ref(1);
+        req->free_yourself();
+    }
+}
+
 #ifdef _PRERELEASE
 bool HomeBlocksImpl::delay_fake_io(VolumePtr v) {
     if (iomgr_flip::instance()->delay_flip("vol_fake_io_delay_simulation", [this, v]() mutable {
@@ -312,6 +325,7 @@ bool HomeBlocksImpl::delay_fake_io(VolumePtr v) {
             v->dec_ref();
         })) {
         LOGI("Slow down vol fake IO flip is enabled, scheduling to call later.");
+        v->inc_ref();
         return true;
     }
     return false;


### PR DESCRIPTION
Changes:
========
1. Remove all inc_ref/dec_ref from volume layer and concentrate to vol_interface_req, so that we only have one place for increase and decrease and caller doesn't need to worry about failure path.
2. add a new test case to cover shutdown with outstanding remove of volume.


Testing:
=======
New Test passed 
```
[06/13/25 15:36:52-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:122:can_shutdown] Shutdown cannot proceed, outstanding requests: 0
[06/13/25 15:36:52-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:133:do_shutdown] Outstanding requests exist, will retry shutdown in 2 seconds
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:127:do_shutdown] Shutdown timer triggered, checking for outstanding requests
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:99:no_outstanding_vols] Found outstanding volume 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71 that is under destruction.
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:122:can_shutdown] Shutdown cannot proceed, outstanding requests: 0
[06/13/25 15:36:54-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:133:do_shutdown] Outstanding requests exist, will retry shutdown in 2 seconds
[06/13/25 15:36:56-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:425:vol_gc] Checking volume with id: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71, is_destroying: true, can_remove: true, num_outstanding_reqs: 0
[06/13/25 15:36:56-07:00] [I] [test_volume] [230542] [homeblks_impl.cpp:438:vol_gc] Garbage Collecting removed volume with id: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71
[06/13/25 15:36:56-07:00] [I] [test_volume] [230503] [volume_mgr.cpp:110:operator()] remove_volume with input id: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71
[06/13/25 15:36:56-07:00] [I] [test_volume] [230503] [volume.cpp:104:destroy] Start destroying volume: vol_0, uuid: 82e1f1cf-cd64-43a9-a12e-8ac962f5ae71
```